### PR TITLE
Bring "@jaredly/get-changed-files" into our actions monorepo, stripping it down to only what we need

### DIFF
--- a/.changeset/breezy-news-greet.md
+++ b/.changeset/breezy-news-greet.md
@@ -1,0 +1,5 @@
+---
+"get-changed-files": major
+---
+
+First release! bringing in jaredly/get-changed-files, and stripping it down to be only what we need.

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -12,3 +12,7 @@ jobs:
       - uses: ./actions/check-for-changeset
       - uses: ./actions/shared-node-cache
       - run: yarn lint
+      
+      - uses: ./actions/get-changed-files
+        id: changed
+      - run: echo '${{ steps.changed.outputs.files }}'

--- a/actions/get-changed-files/action.yml
+++ b/actions/get-changed-files/action.yml
@@ -4,6 +4,10 @@ inputs:
   token:
     description: secrets.GITHUB_TOKEN
     required: true
+outputs:
+  files:
+    description: A jsonified array of files that were added, modified, or renamed.
+    value: ${{ steps.result.outputs.files }}
 runs:
   using: "composite"
   steps:
@@ -11,4 +15,8 @@ runs:
       id: result
       with:
         script: |
-          require('./index.js')({github, context, core})
+          try {
+            require('./index.js')({github, context, core}).catch(err => core.setFailed(err.message))
+          } catch (err) {
+            core.setFailed(err.message)
+          }

--- a/actions/get-changed-files/action.yml
+++ b/actions/get-changed-files/action.yml
@@ -11,7 +11,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/github-scripts@v6
+    - uses: actions/github-script@v6
       id: result
       with:
         script: |

--- a/actions/get-changed-files/action.yml
+++ b/actions/get-changed-files/action.yml
@@ -1,0 +1,14 @@
+name: Get Changed Files
+description: Get a list of the files that have change in this pull-request or push
+inputs:
+  token:
+    description: secrets.GITHUB_TOKEN
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/github-scripts@v6
+      id: result
+      with:
+        script: |
+          require('./index.js')({github, context, core})

--- a/actions/get-changed-files/action.yml
+++ b/actions/get-changed-files/action.yml
@@ -16,7 +16,7 @@ runs:
       with:
         script: |
           try {
-            require('./index.js')({github, context, core}).catch(err => core.setFailed(err.message))
+            require('./actions/get-changed-files/index.js')({github, context, core}).catch(err => core.setFailed(err.message))
           } catch (err) {
             core.setFailed(err.message)
           }

--- a/actions/get-changed-files/index.js
+++ b/actions/get-changed-files/index.js
@@ -1,0 +1,73 @@
+// Get the changed files for a pull-request or push
+
+const getBaseAndHead = (context, core) => {
+    switch (context.eventName) {
+        case "pull_request_target":
+        case "pull_request":
+            return [
+                context.payload.pull_request?.base?.ref,
+                context.payload.pull_request?.head?.sha,
+            ];
+        case "push":
+            return [context.payload.before, context.payload.after];
+        default:
+            core.setFailed(
+                `This action only supports pull requests and pushes, ${context.eventName} events are not supported. ` +
+                    "Please submit an issue on this action's GitHub repo if you believe this in correct.",
+            );
+    }
+};
+
+module.exports = async ({github, context, core}) => {
+    const absolute = !!core.getInput("absolute", {required: false});
+
+    const [base, head] = getBaseAndHead(context, core);
+    core.info(`Base: ${base}\nHead: ${head}`);
+
+    // Ensure that the base and head properties are set on the payload.
+    if (!base || !head) {
+        core.setFailed(
+            `The base and head commits are missing from the payload for this ${context.eventName} event.`,
+        );
+        return;
+    }
+
+    // Use GitHub's compare two commits API.
+    // https://developer.github.com/v3/repos/commits/#compare-two-commits
+    const response = await github.repos.compareCommits({
+        base,
+        head,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+    });
+
+    // Ensure that the request was successful.
+    if (response.status !== 200) {
+        core.setFailed(
+            `The GitHub API for comparing the base and head commits for this ${context.eventName} event returned ${response.status}, expected 200.`,
+        );
+    }
+
+    const files = response.data.files.filter((file) =>
+        ["added", "modified", "renamed"].includes(file.status),
+    );
+    const fileNames = files.map((file) =>
+        absolute
+            ? join(process.env.GITHUB_WORKSPACE, file.filename)
+            : file.filename,
+    );
+    const serialized = JSON.stringify(fileNames);
+
+    core.info(`Added or renamed or modified: ${serialized}`);
+    core.setOutput("files", serialized);
+};
+
+const join = (base, name) => {
+    if (!base || !base.length) {
+        return name;
+    }
+    if (!base.endsWith("/")) {
+        base += "/";
+    }
+    return base + name;
+};

--- a/actions/get-changed-files/index.js
+++ b/actions/get-changed-files/index.js
@@ -34,7 +34,7 @@ module.exports = async ({github, context, core}) => {
 
     // Use GitHub's compare two commits API.
     // https://developer.github.com/v3/repos/commits/#compare-two-commits
-    const response = await github.repos.compareCommits({
+    const response = await github.rest.repos.compareCommits({
         base,
         head,
         owner: context.repo.owner,

--- a/actions/get-changed-files/package.json
+++ b/actions/get-changed-files/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "gerald-pr",
+	"version": "0.0.0"
+}

--- a/actions/get-changed-files/package.json
+++ b/actions/get-changed-files/package.json
@@ -1,4 +1,4 @@
 {
-	"name": "gerald-pr",
-	"version": "0.0.0"
+    "name": "get-changed-files",
+    "version": "0.0.0"
 }

--- a/utils/build.mjs
+++ b/utils/build.mjs
@@ -28,8 +28,13 @@ export const processActionYml = (
     actionYml,
     monorepoName,
 ) => {
+    // This first replacement is to rewrite local requires, in the case where we have
+    // a github-script action with e.g. `require('./actions/my-action/index.js')`. Writing
+    // it this way means it will work in this repo without publishing (so our workflows can
+    // use it directly), and then we do this replacement when publishing so it will work there
+    // too.
     const replacements = [{from: new RegExp(`\\./actions/${name}/`), to: "./"}];
-    Object.keys(packageJsons[name].dependencies || {}).forEach((depName) => {
+    Object.keys(packageJsons[name].dependencies ?? {}).forEach((depName) => {
         replacements.push({
             from: new RegExp(`\\buses: \\./actions/${depName}\\b`, "g"),
             to: `uses: ${monorepoName}@${depName}-v${packageJsons[depName].version}`,

--- a/utils/build.mjs
+++ b/utils/build.mjs
@@ -48,13 +48,11 @@ export const buildPackage = (name, packageJsons, monorepoName) => {
         fs.rmSync(dist, {recursive: true});
     }
     copyDir(`actions/${name}`, dist);
-    // if (packageJsons[name].dependencies) {
     const yml = `actions/${name}/dist/action.yml`;
     const actionYml = fs.readFileSync(yml, "utf8");
     fs.writeFileSync(
         yml,
         processActionYml(name, packageJsons, actionYml, monorepoName),
     );
-    // }
     return dist;
 };

--- a/utils/build.mjs
+++ b/utils/build.mjs
@@ -28,8 +28,8 @@ export const processActionYml = (
     actionYml,
     monorepoName,
 ) => {
-    const replacements = [];
-    Object.keys(packageJsons[name].dependencies).forEach((depName) => {
+    const replacements = [{from: new RegExp(`\\./actions/${name}/`), to: "./"}];
+    Object.keys(packageJsons[name].dependencies || {}).forEach((depName) => {
         replacements.push({
             from: new RegExp(`\\buses: \\./actions/${depName}\\b`, "g"),
             to: `uses: ${monorepoName}@${depName}-v${packageJsons[depName].version}`,
@@ -48,13 +48,13 @@ export const buildPackage = (name, packageJsons, monorepoName) => {
         fs.rmSync(dist, {recursive: true});
     }
     copyDir(`actions/${name}`, dist);
-    if (packageJsons[name].dependencies) {
-        const yml = `actions/${name}/dist/action.yml`;
-        const actionYml = fs.readFileSync(yml, "utf8");
-        fs.writeFileSync(
-            yml,
-            processActionYml(name, packageJsons, actionYml, monorepoName),
-        );
-    }
+    // if (packageJsons[name].dependencies) {
+    const yml = `actions/${name}/dist/action.yml`;
+    const actionYml = fs.readFileSync(yml, "utf8");
+    fs.writeFileSync(
+        yml,
+        processActionYml(name, packageJsons, actionYml, monorepoName),
+    );
+    // }
     return dist;
 };

--- a/utils/build.test.mjs
+++ b/utils/build.test.mjs
@@ -10,6 +10,10 @@ runs:
   steps:
     - name: Limited run
       uses: ./actions/json-args
+    - uses: actions/github-script@v6
+      with:
+        script: |
+          require('./actions/full-or-limited/index.js')({github, core})
 `;
         expect(
             processActionYml(
@@ -39,6 +43,10 @@ runs:
               steps:
                 - name: Limited run
                   uses: Our/monorepo@json-args-v1.2.3
+                - uses: actions/github-script@v6
+                  with:
+                    script: |
+                      require('./index.js')({github, core})
             "
         `);
     });


### PR DESCRIPTION
## Summary:
We've unified around json encoding to deal with spaces, and we only ever ask for added_modified and renamed, so I merged them together.

This is my first time trying `actions/github-script` with a local require, and it turns out it's relative to the repo base (which makes sense). Because of this, I had to change `build.mjs` to turn `require('./actions/get-changed-files/index.js')` into `require('./index.js')` when publishing these actions individually.

Issue: XXX-XXXX

## Test plan:
See the check on this one!

<img width="1488" alt="image" src="https://user-images.githubusercontent.com/112170/170351762-249bec46-539c-4c2e-a905-7547ff916a4e.png">
