### PR TITLE
Exclude the changeset-release/main branch from the changeset check, and .github/-only changes

### DIFF
--- a/actions/check-for-changeset/action.yml
+++ b/actions/check-for-changeset/action.yml
@@ -3,25 +3,10 @@ description: 'Fail if no .changeset/*.md file is included in the PR.'
 runs:
   using: "composite"
   steps:
-    - name: "Get All Changed Files"
+    - uses: Khan/actions@get-changed-files-v1
       id: changed
-      uses: jaredly/get-changed-files@v1.0.1
-      with:
-        format: json
     - uses: actions/github-script@v6
       with:
         script: |
-          const inputFiles = JSON.parse(`${{ steps.changed.outputs.added_modified }}`);
-          core.debug("Changed files: " + inputFiles);
-
-          const hasChangeset = inputFiles.some(name => {
-            return /^\.changeset\/.*\.md/.test(name);
-          });
-          if (!hasChangeset) {
-            core.setFailed(
-              "This PR does not have a changeset. You can add one by " +
-              "running `yarn changeset` and following the prompts.\n" +
-              "If this PR doesn't need a changeset, run `yarn changeset " +
-              "--empty` and commit results."
-            );
-          }
+          const inputFiles = JSON.parse(`${{ steps.changed.outputs.files }}`);
+          require('./actions/check-for-changeset/index.js')({context, core, inputFiles})

--- a/actions/check-for-changeset/index.js
+++ b/actions/check-for-changeset/index.js
@@ -1,0 +1,24 @@
+module.exports = ({context, core, inputFiles}) => {
+    core.debug("Changed files: " + inputFiles);
+    core.debug(process.env.GITHUB_REF_NAME);
+
+    if (process.env.GITHUB_REF_NAME === "changeset-release/main") {
+        return; // release PRs don't need changesets.
+    }
+
+    if (inputFiles.every((name) => name.startsWith(".github/"))) {
+        return; // changes to workflows don't require changesets
+    }
+
+    const hasChangeset = inputFiles.some((name) => {
+        return /^\.changeset\/.*\.md/.test(name);
+    });
+    if (!hasChangeset) {
+        core.setFailed(
+            "This PR does not have a changeset. You can add one by " +
+                "running `yarn changeset` and following the prompts.\n" +
+                "If this PR doesn't need a changeset, run `yarn changeset " +
+                "--empty` and commit results.",
+        );
+    }
+};


### PR DESCRIPTION
## Summary:
To require the --empty a little less often.

Issue: XXX-XXXX

## Test plan:
See this check to verify that it's still working for normal PRs.