### PR TITLE
Add 'invert' option to filter-files

### DIFF
--- a/.changeset/silver-phones-collect.md
+++ b/.changeset/silver-phones-collect.md
@@ -1,0 +1,5 @@
+---
+"filter-files": minor
+---
+
+Add the 'invert' option, to return unmatched paths instead of matched ones.

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -62,7 +62,7 @@ jobs:
               core.setFailed(fftest4)
             }
             const fftest5 = `${{ steps.fftest5.outputs.filtered }}`;
-            if (fftest5 !== `["one", "two/three/four"]`) {
+            if (fftest5 !== `["one","two/three/four"]`) {
               core.setFailed(fftest5)
             }
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -34,6 +34,12 @@ jobs:
         with:
           changed-files: '["one", "two/three", "two/three/four"]'
           files: 'two/three'
+      - uses: ./actions/filter-files
+        id: fftest5
+        with:
+          changed-files: '["one", "two/three", "two/three/four"]'
+          files: 'two/three'
+          invert: true
 
       - uses: actions/github-script@v6
         name: Test the 'filter-files' action
@@ -54,6 +60,10 @@ jobs:
             const fftest4 = `${{ steps.fftest4.outputs.filtered }}`;
             if (fftest4 !== `["two/three"]`) {
               core.setFailed(fftest4)
+            }
+            const fftest5 = `${{ steps.fftest5.outputs.filtered }}`;
+            if (fftest5 !== `["one", "two/three/four"]`) {
+              core.setFailed(fftest5)
             }
 
       - uses: ./actions/get-changed-files

--- a/actions/filter-files/action.yml
+++ b/actions/filter-files/action.yml
@@ -10,6 +10,9 @@ inputs:
   extensions:
     description: 'comma-separated list of extensions to check for'
     required: false
+  invert:
+    description: 'if true, return the non-matched paths instead of the matched ones.'
+    required: false
 outputs:
   filtered:
     description: 'The jsonified list of files that match'
@@ -27,11 +30,13 @@ runs:
           const extensions = extensionsRaw.trim() ? extensionsRaw.split(',') : [];
           const exactFiles = exactFilesRaw.trim() ? exactFilesRaw.split(',') : [];
           const directories = exactFiles.filter(name => name.endsWith('/'));
+          const invert = "${{ inputs.invert }}" == 'true';
 
           const result = inputFiles.filter(name => {
-            return extensions.some(ext => name.endsWith(ext)) || (
+            const matched = extensions.some(ext => name.endsWith(ext)) || (
               exactFiles.includes(name)
             ) || directories.some(dir => name.startsWith(dir))
+            return matched === !invert
           })
           console.log(`Filtered Files: ${JSON.stringify(result)}`)
           return result;


### PR DESCRIPTION
## Summary:
This allows you to filter-out paths instead of filtering for them. To used in check-for-changeset.

Issue: XXX-XXXX

## Test plan:
see example workflow