### PR TITLE
Add a 'directories' option to get-changed-files, for prefiltering by directory

### DIFF
--- a/.changeset/fifty-bottles-travel.md
+++ b/.changeset/fifty-bottles-travel.md
@@ -1,0 +1,5 @@
+---
+"get-changed-files": minor
+---
+
+Add a 'directories' option to get-changed-files, for prefiltering by directory

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -69,6 +69,13 @@ jobs:
             }
 
       - uses: ./actions/get-changed-files
+        id: changed-limited
+        with:
+          directories: |
+            .github/
+            .changeset
+
+      - uses: ./actions/get-changed-files
         id: changed
       - run: echo '${{ steps.changed.outputs.files }}'
 

--- a/actions/get-changed-files/action.yml
+++ b/actions/get-changed-files/action.yml
@@ -4,6 +4,9 @@ inputs:
   token:
     description: secrets.GITHUB_TOKEN
     required: true
+  directories:
+    description: Prefilter results to only the listed subdirectories (newline-separated)
+    required: false
 outputs:
   files:
     description: A jsonified array of files that were added, modified, or renamed.
@@ -16,7 +19,10 @@ runs:
       with:
         script: |
           try {
-            require('./actions/get-changed-files/index.js')({github, context, core}).catch(err => core.setFailed(err.message))
+            require('./actions/get-changed-files/index.js')({
+              github, context, core,
+              directoriesRaw: `${{ inputs.directories }}`,
+            }).catch(err => core.setFailed(err.message))
           } catch (err) {
             core.setFailed(err.message)
           }


### PR DESCRIPTION
## Summary:
I thought about allowing regexes, or minimatch or something like that, but I don't think we need to get that complicated. If you want to really drill down, that's what filter-files is for.

Issue: XXX-XXXX

## Test plan:
See the node-ci workflow