### PR TITLE
Simpler failure message when a json-args command fails

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -79,6 +79,13 @@ jobs:
         id: changed
       - run: echo '${{ steps.changed.outputs.files }}'
 
+      # Test json-args with a failing command
+      - uses: ./actions/json-args
+        continue-on-error: true
+        with:
+          list: '["hi","folks with space"]'
+          run: node -e 'console.log(process.argv); process.exit(1)' {}
+
       - uses: ./actions/check-for-changeset
         with:
           exclude: .github/,utils,.eslintrc.js,.prettierrc.js

--- a/actions/json-args/action.yml
+++ b/actions/json-args/action.yml
@@ -27,6 +27,10 @@ runs:
             cmd += ' ' + filesList;
           }
           console.log(`Running: ${cmd}`);
-          execSync(cmd, {
-            stdio: 'inherit',
-          })
+          try {
+            execSync(cmd, {
+              stdio: 'inherit',
+            })
+          } catch (err) {
+            core.setFailed(`Command ${cmd} failed: ${err}`)
+          }


### PR DESCRIPTION
## Summary:
Currently it's just bubbling up as a javascript error, which is unnecessarily noisy.

Issue: XXX-XXXX

## Test plan:
See node-ci.yml