### PR TITLE
Remove the need to specify dependencies between actions

### DIFF
--- a/.changeset/modern-starfishes-travel.md
+++ b/.changeset/modern-starfishes-travel.md
@@ -1,0 +1,5 @@
+---
+"json-args": minor
+---
+
+Simpler failure message when a json-args command fails

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -79,6 +79,13 @@ jobs:
         id: changed
       - run: echo '${{ steps.changed.outputs.files }}'
 
+      # Test json-args with a failing command
+      - uses: ./actions/json-args
+        continue-on-error: true
+        with:
+          list: '["hi","folks with space"]'
+          run: node -e 'console.log(process.argv); process.exit(1)' {}
+
       - uses: ./actions/check-for-changeset
         with:
           exclude: .github/,utils,.eslintrc.js,.prettierrc.js

--- a/actions/full-or-limited/package.json
+++ b/actions/full-or-limited/package.json
@@ -1,7 +1,4 @@
 {
     "name": "full-or-limited",
-    "version": "0.0.0",
-    "dependencies": {
-        "json-args": "*"
-    }
+    "version": "0.0.0"
 }

--- a/actions/json-args/action.yml
+++ b/actions/json-args/action.yml
@@ -32,5 +32,5 @@ runs:
               stdio: 'inherit',
             })
           } catch (err) {
-            core.setFailed(`Command ${cmd} failed: ${err}`)
+            core.setFailed(err.toString())
           }

--- a/actions/json-args/action.yml
+++ b/actions/json-args/action.yml
@@ -27,6 +27,10 @@ runs:
             cmd += ' ' + filesList;
           }
           console.log(`Running: ${cmd}`);
-          execSync(cmd, {
-            stdio: 'inherit',
-          })
+          try {
+            execSync(cmd, {
+              stdio: 'inherit',
+            })
+          } catch (err) {
+            core.setFailed(`Command ${cmd} failed: ${err}`)
+          }

--- a/utils/build.mjs
+++ b/utils/build.mjs
@@ -40,10 +40,13 @@ export const processActionYml = (
             to: "${{ github.action_path }}/",
         },
     ];
-    Object.keys(packageJsons).forEach((depName) => {
+    const allActionNames = Object.keys(packageJsons);
+    // For each of the other actions, replace any local-path references to it
+    // to a normal action reference, locked to the current latest version.
+    allActionNames.forEach((actionName) => {
         replacements.push({
-            from: new RegExp(`\\buses: \\./actions/${depName}\\b`, "g"),
-            to: `uses: ${monorepoName}@${depName}-v${packageJsons[depName].version}`,
+            from: new RegExp(`\\buses: \\./actions/${actionName}\\b`, "g"),
+            to: `uses: ${monorepoName}@${actionName}-v${packageJsons[actionName].version}`,
         });
     });
     replacements.forEach(({from, to}) => {

--- a/utils/build.mjs
+++ b/utils/build.mjs
@@ -40,7 +40,7 @@ export const processActionYml = (
             to: "${{ github.action_path }}/",
         },
     ];
-    Object.keys(packageJsons[name].dependencies ?? {}).forEach((depName) => {
+    Object.keys(packageJsons).forEach((depName) => {
         replacements.push({
             from: new RegExp(`\\buses: \\./actions/${depName}\\b`, "g"),
             to: `uses: ${monorepoName}@${depName}-v${packageJsons[depName].version}`,

--- a/utils/publish.mjs
+++ b/utils/publish.mjs
@@ -34,6 +34,7 @@ export const publishDirectoryAsTags = (
         `git tag ${majorTag}`,
     ];
     if (!dryRun) {
+        cmds.push(`git push origin :refs/tags/${tag}`);
         cmds.push(`git push origin ${tag}`);
         // This will succeed with a warning if the major tag doesn't exist
         cmds.push(`git push origin :refs/tags/${majorTag}`);
@@ -70,7 +71,7 @@ export const publishAsNeeded = (packageNames, dryRun = false) => {
         const majorVersion = version.split(".")[0];
         const tag = `${name}-v${version}`;
         const majorTag = `${name}-v${majorVersion}`;
-        if (!checkTag(tag)) {
+        if (!checkTag(tag) || name === "check-for-changeset") {
             const distPath = buildPackage(name, packageJsons, `Khan/actions`);
             publishDirectoryAsTags(distPath, origin, tag, majorTag, dryRun);
         }

--- a/utils/publish.mjs
+++ b/utils/publish.mjs
@@ -34,7 +34,6 @@ export const publishDirectoryAsTags = (
         `git tag ${majorTag}`,
     ];
     if (!dryRun) {
-        cmds.push(`git push origin :refs/tags/${tag}`);
         cmds.push(`git push origin ${tag}`);
         // This will succeed with a warning if the major tag doesn't exist
         cmds.push(`git push origin :refs/tags/${majorTag}`);
@@ -71,7 +70,7 @@ export const publishAsNeeded = (packageNames, dryRun = false) => {
         const majorVersion = version.split(".")[0];
         const tag = `${name}-v${version}`;
         const majorTag = `${name}-v${majorVersion}`;
-        if (!checkTag(tag) || name === "check-for-changeset") {
+        if (!checkTag(tag)) {
             const distPath = buildPackage(name, packageJsons, `Khan/actions`);
             publishDirectoryAsTags(distPath, origin, tag, majorTag, dryRun);
         }


### PR DESCRIPTION
## Summary:
I made an error with check-for-changeset, by using another action (`./actions/get-changed-files`) but not listing it in package.json. It worked for local testing, but didn't get translated correctly on build.
This makes it so that all inter-action dependencies get automatically resolved.

Issue: XXX-XXXX

## Test plan:
See the failed version https://github.com/Khan/wonder-blocks/runs/6714028552?check_suite_focus=true
and the succeeding version https://github.com/Khan/wonder-blocks/runs/6714266788?check_suite_focus=true