### PR TITLE
Skip gerald steps if the PR is a draft

### DIFF
--- a/.changeset/quiet-mails-attack.md
+++ b/.changeset/quiet-mails-attack.md
@@ -1,0 +1,5 @@
+---
+"gerald-pr": minor
+---
+
+Skip gerald steps if the PR is a draft

--- a/actions/gerald-pr/action.yml
+++ b/actions/gerald-pr/action.yml
@@ -15,20 +15,25 @@ runs:
         id: changed
         with:
           format: 'json'
+        if: ${{ github.event.pull_request.draft == false }}
       - uses: allenevans/set-env@v2.0.0
         with:
           ALL_CHANGED_FILES: '${{ steps.changed.outputs.added_modified }}'
+        if: ${{ github.event.pull_request.draft == false }}
       - name: Check out base branch
         uses: actions/checkout@v2
         with:
           ref: '${{ github.base_ref }}'
+        if: ${{ github.event.pull_request.draft == false }}
       - name: Check out head branch
         uses: actions/checkout@v2
         with:
           ref: '${{ github.head_ref }}'
+        if: ${{ github.event.pull_request.draft == false }}
       - name: Run Gerald
         uses: Khan/gerald@main
         env:
           GITHUB_TOKEN: '${{ inputs.token }}'
           ADMIN_PERMISSION_TOKEN: '${{ inputs.admin-token }}'
           EVENT: 'pull_request'
+        if: ${{ github.event.pull_request.draft == false }}


### PR DESCRIPTION
## Summary:
We /could/ fix this by putting an `if` on all of the gerald workflows in all of the repos, but this will fix it centrally for all.

Issue: XXX-XXXX

## Test plan:
Make a draft PR off of this one, see that the "gerald" step is skipped, and doesn't auto-assign reviewers
https://github.com/Khan/actions/pull/28 yay