### PR TITLE
Fix publishing on CI by adding github user.email & name

### DIFF
--- a/utils/publish.mjs
+++ b/utils/publish.mjs
@@ -28,6 +28,8 @@ export const publishDirectoryAsTags = (
     const cmds = [
         `git init .`,
         `git add .`,
+        `git config user.email "khan-actions-bot@khanacademy.org"`,
+        `git config user.name "Khan Actions Bot"`,
         `git commit -m publish`,
         `git remote add origin ${origin}`,
         `git tag ${tag}`,


### PR DESCRIPTION
## Summary:
Git will refuse to commit stuff if it doesn't know who you are, which is fine I guess.
Here's what it looks like failing: https://github.com/Khan/actions/runs/6814703962

Issue: XXX-XXXX

## Test plan:
Next time we release it should work 🤞