### PR TITLE
Add 'setup-keeper' action for setting up keeper with authentication

### DIFF
--- a/.changeset/weak-parrots-refuse.md
+++ b/.changeset/weak-parrots-refuse.md
@@ -1,0 +1,5 @@
+---
+"setup-keeper": major
+---
+
+Introducing: setup-keeper! If you give it a valid KEEPER_CONFIG as the `config` input, it will set up keeper for you, as well as the env vbl needed so `keeper` commands will work without specifying a config by hand.

--- a/.github/workflows/keeper.yml
+++ b/.github/workflows/keeper.yml
@@ -15,3 +15,6 @@ jobs:
       - uses: ./actions/setup-keeper
         with:
           config: ${{ secrets.KEEPER_CONFIG }}
+      - name: Ensure that the env vbl made its way out of that action
+        run: |
+          keeper whoami | grep '@khanacademy.org'

--- a/.github/workflows/keeper.yml
+++ b/.github/workflows/keeper.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    name: Lints
+    name: Verify keeper installation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/keeper.yml
+++ b/.github/workflows/keeper.yml
@@ -1,0 +1,17 @@
+name: Keeper
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/keeper.yml
+      - actions/setup-keeper/**
+
+jobs:
+  check:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./actions/setup-keeper
+        with:
+          config: ${{ secrets.KEEPER_CONFIG }}

--- a/actions/setup-keeper/action.yml
+++ b/actions/setup-keeper/action.yml
@@ -1,0 +1,37 @@
+name: Setup Keeper
+description: Install keeper & set up authentication
+inputs:
+  config:
+    description: contents of the keeper config file
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: setup for linux
+      if: ${{ runner.os === "Linux" }}
+      shell: bash
+      run: |
+        sudo apt-get -y install python3-setuptools
+        pip3 install wheel
+        # On 2/26/2021, this step started failing, because keepercommander brings down cryptography
+        # which needs setuptools_rust, but wasn't finding it. Manually installing setuptools_rust
+        # fixes that problem, but perhaps once cryptography is updated, we will no longer need this
+        # extra step? So, maybe delete later
+        pip3 install setuptools_rust
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        export PATH=$PATH:$HOME/.local/bin
+
+    - name: install keepercommander
+      shell: bash
+      run: pip3 install keepercommander==16.6.5
+
+    - name: Set up the keeper config file
+      shell: bash
+      run: |
+        cat << EOF > $HOME/.keeper-config.json
+        ${{ inputs.config }}
+        EOF
+        echo "KEEPER_CONFIG_FILE=$HOME/.keeper-config.json" >> $GITHUB_ENV
+
+    - name: Check that keeper is installed correctly
+      run: keeper whoami

--- a/actions/setup-keeper/action.yml
+++ b/actions/setup-keeper/action.yml
@@ -21,4 +21,4 @@ runs:
 
     - name: Check that keeper is installed correctly
       shell: bash
-      run: keeper whoami | grep notexistent
+      run: keeper whoami | grep '@khanacademy.org'

--- a/actions/setup-keeper/action.yml
+++ b/actions/setup-keeper/action.yml
@@ -7,19 +7,19 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: setup for linux
-      if: ${{ runner.os === "Linux" }}
-      shell: bash
-      run: |
-        sudo apt-get -y install python3-setuptools
-        pip3 install wheel
-        # On 2/26/2021, this step started failing, because keepercommander brings down cryptography
-        # which needs setuptools_rust, but wasn't finding it. Manually installing setuptools_rust
-        # fixes that problem, but perhaps once cryptography is updated, we will no longer need this
-        # extra step? So, maybe delete later
-        pip3 install setuptools_rust
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
-        export PATH=$PATH:$HOME/.local/bin
+    # - name: setup for linux
+    #   if: ${{ runner.os == "Linux" }}
+    #   shell: bash
+    #   run: |
+    #     # sudo apt-get -y install python3-setuptools
+    #     # pip3 install wheel
+    #     # # On 2/26/2021, this step started failing, because keepercommander brings down cryptography
+    #     # # which needs setuptools_rust, but wasn't finding it. Manually installing setuptools_rust
+    #     # # fixes that problem, but perhaps once cryptography is updated, we will no longer need this
+    #     # # extra step? So, maybe delete later
+    #     # pip3 install setuptools_rust
+    #     echo "$HOME/.local/bin" >> $GITHUB_PATH
+    #     export PATH=$PATH:$HOME/.local/bin
 
     - name: install keepercommander
       shell: bash
@@ -34,4 +34,5 @@ runs:
         echo "KEEPER_CONFIG_FILE=$HOME/.keeper-config.json" >> $GITHUB_ENV
 
     - name: Check that keeper is installed correctly
+      shell: bash
       run: keeper whoami

--- a/actions/setup-keeper/action.yml
+++ b/actions/setup-keeper/action.yml
@@ -7,23 +7,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # - name: setup for linux
-    #   if: ${{ runner.os == "Linux" }}
-    #   shell: bash
-    #   run: |
-    #     # sudo apt-get -y install python3-setuptools
-    #     # pip3 install wheel
-    #     # # On 2/26/2021, this step started failing, because keepercommander brings down cryptography
-    #     # # which needs setuptools_rust, but wasn't finding it. Manually installing setuptools_rust
-    #     # # fixes that problem, but perhaps once cryptography is updated, we will no longer need this
-    #     # # extra step? So, maybe delete later
-    #     # pip3 install setuptools_rust
-    #     echo "$HOME/.local/bin" >> $GITHUB_PATH
-    #     export PATH=$PATH:$HOME/.local/bin
-
     - name: install keepercommander
       shell: bash
-      run: pip3 install keepercommander==16.6.5
+      run: pip3 install cryptography==37.0.2 keepercommander==16.6.5
 
     - name: Set up the keeper config file
       shell: bash

--- a/actions/setup-keeper/action.yml
+++ b/actions/setup-keeper/action.yml
@@ -9,7 +9,7 @@ runs:
   steps:
     - name: install keepercommander
       shell: bash
-      run: pip3 install cryptography==37.0.2 keepercommander==16.6.5
+      run: pip3 install cryptography==37.0.2 pyOpenSSL==22.0.0 keepercommander==16.6.5
 
     - name: Set up the keeper config file
       shell: bash
@@ -21,4 +21,4 @@ runs:
 
     - name: Check that keeper is installed correctly
       shell: bash
-      run: keeper whoami
+      run: keeper whoami | grep notexistent

--- a/actions/setup-keeper/package.json
+++ b/actions/setup-keeper/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "setup-keeper",
+    "version": "0.1.0"
+}


### PR DESCRIPTION
## Summary:
The mobile keeper setup is breaking, and webapp wants to start using keeper in github actions, so might as well make something shared.

Where did KEEPER_CONFIG come from?

Make this as a local file on your machine, e.g. keeper-config.json
```json
{
    "server": "keepersecurity.com",
    "user": "[the keeper username that we use for jenkins]",
    "password": "[the password for jenkins keeper account]",
    "private_key": "",
    "device_token": "",
    "clone_code": ""
}
```
Then run:
```bash
$ keeper --config keeper-config.json shell
> # (you'll have some SSO rigamarole, make sure to open a private window so you can login as our jenkins account; the google password for this account is also in keeper)
My Vault> this-device register
My Vault> this-device persistent-login on
My Vault> this-device ip-auto-approve on
My Vault> this-device timeout 365d
```
Then that config file will be populated w/ the private key, device token, and clone code. Copy the contents of that file into github's "secrets" ui as KEEPER_CONFIG, and you should be good to go!

Issue: XXX-XXXX

## Test plan:
See the checks