### PR TITLE
Make setup-keeper action less flaky

### DIFF
--- a/.changeset/brown-crabs-vanish.md
+++ b/.changeset/brown-crabs-vanish.md
@@ -1,0 +1,5 @@
+---
+"setup-keeper": patch
+---
+
+Use github-script instead of bash heredocs because it seems to work better

--- a/.github/workflows/keeper.yml
+++ b/.github/workflows/keeper.yml
@@ -6,6 +6,7 @@ on:
       - .github/workflows/keeper.yml
       - actions/setup-keeper/**
 
+# Check it out
 jobs:
   check:
     name: Verify keeper installation

--- a/.github/workflows/keeper.yml
+++ b/.github/workflows/keeper.yml
@@ -6,7 +6,6 @@ on:
       - .github/workflows/keeper.yml
       - actions/setup-keeper/**
 
-# Check it out
 jobs:
   check:
     name: Verify keeper installation

--- a/.github/workflows/keeper.yml
+++ b/.github/workflows/keeper.yml
@@ -18,4 +18,4 @@ jobs:
           config: ${{ secrets.KEEPER_CONFIG }}
       - name: Ensure that the env vbl made its way out of that action
         run: |
-          keeper whoami | grep '@khanacademy.org'
+          keeper whoami

--- a/.github/workflows/keeper.yml
+++ b/.github/workflows/keeper.yml
@@ -18,4 +18,4 @@ jobs:
           config: ${{ secrets.KEEPER_CONFIG }}
       - name: Ensure that the env vbl made its way out of that action
         run: |
-          keeper whoami
+          keeper whoami | grep '@khanacademy.org'

--- a/actions/setup-keeper/action.yml
+++ b/actions/setup-keeper/action.yml
@@ -15,7 +15,7 @@ runs:
       with:
         script:
           const config = `${{ inputs.config }}`;
-          require('fs').writeFileSync('./.keeper-config.json', config)
+          require('fs').writeFileSync(process.env.HOME + '/.keeper-config.json', config)
 
     - name: Set up the keeper config file
       shell: bash

--- a/actions/setup-keeper/action.yml
+++ b/actions/setup-keeper/action.yml
@@ -11,16 +11,16 @@ runs:
       shell: bash
       run: pip3 install cryptography==37.0.2 pyOpenSSL==22.0.0 keepercommander==16.6.5
 
+    - uses: actions/github-script@v6
+      with:
+        script:
+          const config = `${{ inputs.config }}`;
+          require('fs').writeFileSync(process.env.HOME + '/.keeper-config.json', config)
+
     - name: Set up the keeper config file
       shell: bash
-      run: |
-        cat << EOF > $HOME/.keeper-config.json
-        ${{ inputs.config }}
-        EOF
-        echo "KEEPER_CONFIG_FILE=$HOME/.keeper-config.json" >> $GITHUB_ENV
+      run: echo "KEEPER_CONFIG_FILE=$HOME/.keeper-config.json" >> $GITHUB_ENV
 
     - name: Check that keeper is installed correctly
       shell: bash
-      run: |
-        keeper this-device
-        keeper whoami
+      run: keeper this-device

--- a/actions/setup-keeper/action.yml
+++ b/actions/setup-keeper/action.yml
@@ -11,15 +11,13 @@ runs:
       shell: bash
       run: pip3 install cryptography==37.0.2 pyOpenSSL==22.0.0 keepercommander==16.6.5
 
-    - uses: actions/github-script@v6
-      with:
-        script:
-          const config = `${{ inputs.config }}`;
-          require('fs').writeFileSync(process.env.HOME + '/.keeper-config.json', config)
-
     - name: Set up the keeper config file
       shell: bash
-      run: echo "KEEPER_CONFIG_FILE=$HOME/.keeper-config.json" >> $GITHUB_ENV
+      run: |
+        cat << EOF > $HOME/.keeper-config.json
+        ${{ inputs.config }}
+        EOF
+        echo "KEEPER_CONFIG_FILE=$HOME/.keeper-config.json" >> $GITHUB_ENV
 
     - name: Check that keeper is installed correctly
       shell: bash

--- a/actions/setup-keeper/action.yml
+++ b/actions/setup-keeper/action.yml
@@ -11,13 +11,15 @@ runs:
       shell: bash
       run: pip3 install cryptography==37.0.2 pyOpenSSL==22.0.0 keepercommander==16.6.5
 
+    - uses: actions/github-script@v6
+      with:
+        script:
+          const config = `${{ secrets.KEEPER_CONFIG }}`;
+          require('fs').writeFileSync('./.keeper-config.json', config)
+
     - name: Set up the keeper config file
       shell: bash
-      run: |
-        cat << EOF > $HOME/.keeper-config.json
-        ${{ inputs.config }}
-        EOF
-        echo "KEEPER_CONFIG_FILE=$HOME/.keeper-config.json" >> $GITHUB_ENV
+      run: echo "KEEPER_CONFIG_FILE=$HOME/.keeper-config.json" >> $GITHUB_ENV
 
     - name: Check that keeper is installed correctly
       shell: bash

--- a/actions/setup-keeper/action.yml
+++ b/actions/setup-keeper/action.yml
@@ -14,7 +14,7 @@ runs:
     - uses: actions/github-script@v6
       with:
         script:
-          const config = `${{ secrets.KEEPER_CONFIG }}`;
+          const config = `${{ inputs.config }}`;
           require('fs').writeFileSync('./.keeper-config.json', config)
 
     - name: Set up the keeper config file

--- a/actions/setup-keeper/action.yml
+++ b/actions/setup-keeper/action.yml
@@ -21,4 +21,6 @@ runs:
 
     - name: Check that keeper is installed correctly
       shell: bash
-      run: keeper whoami | grep '@khanacademy.org'
+      run: |
+        keeper this-device
+        keeper whoami


### PR DESCRIPTION
## Summary:
For some inscrutable reason, using the bash HEREDOC stuff worked a couple of times, and then never again. I trust javascript more anyway, so I'm happy with this change.

## Test plan:
see the check working!