### PR TITLE
Update to use latest actions, removing Node12 dep

### DIFF
--- a/.changeset/young-points-sell.md
+++ b/.changeset/young-points-sell.md
@@ -1,0 +1,5 @@
+---
+"gerald-pr": major
+---
+
+Update to not need Node 12

--- a/.changeset/young-points-sell.md
+++ b/.changeset/young-points-sell.md
@@ -1,5 +1,5 @@
 ---
-"gerald-pr": major
+"gerald-pr": minor
 ---
 
 Update to not need Node 12

--- a/.github/workflows/gerald-pr.yml
+++ b/.github/workflows/gerald-pr.yml
@@ -9,7 +9,7 @@ jobs:
     if: "github.event.action != 'edited' || github.event.changes.base != null"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./actions/gerald-pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/keeper.yml
+++ b/.github/workflows/keeper.yml
@@ -11,7 +11,7 @@ jobs:
     name: Verify keeper installation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./actions/setup-keeper
         with:
           config: ${{ secrets.KEEPER_CONFIG }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: Lints
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./actions/shared-node-cache
       - run: yarn lint
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./actions/shared-node-cache
 
       - name: Create Release Pull Request or Publish as tags

--- a/actions/gerald-pr/action.yml
+++ b/actions/gerald-pr/action.yml
@@ -11,22 +11,16 @@ runs:
   using: "composite"
   steps:
       - name: Get All Changed Files
-        uses: jaredly/get-changed-files@absolute
+        uses: Khan/actions@get-changed-files-v1
         id: changed
-        with:
-          format: 'json'
-        if: ${{ github.event.pull_request.draft == false }}
-      - uses: allenevans/set-env@v2.0.0
-        with:
-          ALL_CHANGED_FILES: '${{ steps.changed.outputs.added_modified }}'
         if: ${{ github.event.pull_request.draft == false }}
       - name: Check out base branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: '${{ github.base_ref }}'
         if: ${{ github.event.pull_request.draft == false }}
       - name: Check out head branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: '${{ github.head_ref }}'
         if: ${{ github.event.pull_request.draft == false }}
@@ -36,4 +30,5 @@ runs:
           GITHUB_TOKEN: '${{ inputs.token }}'
           ADMIN_PERMISSION_TOKEN: '${{ inputs.admin-token }}'
           EVENT: 'pull_request'
+          ALL_CHANGED_FILES: '${{ steps.changed.outputs.all_changed_files }}'
         if: ${{ github.event.pull_request.draft == false }}

--- a/actions/gerald-pr/action.yml
+++ b/actions/gerald-pr/action.yml
@@ -30,5 +30,5 @@ runs:
           GITHUB_TOKEN: '${{ inputs.token }}'
           ADMIN_PERMISSION_TOKEN: '${{ inputs.admin-token }}'
           EVENT: 'pull_request'
-          ALL_CHANGED_FILES: '${{ steps.changed.outputs.all_changed_files }}'
+          ALL_CHANGED_FILES: '${{ steps.changed.outputs.files }}'
         if: ${{ github.event.pull_request.draft == false }}

--- a/actions/shared-node-cache/action.yml
+++ b/actions/shared-node-cache/action.yml
@@ -10,12 +10,12 @@ runs:
   steps:
 
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
 
     - name: Cache node_modules and cypress if it exists
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-node-modules
       with:
         path: |


### PR DESCRIPTION
## Summary:
This updates to use the latest actions and therefore remove the Node 12 dependency that is soon to not even be supported by GitHub Actions.

Issue: FEI-4813

## Test plan:
Put this up, check things are OK. Then update and check the things that use this thing.