### PR TITLE
[🔥AUDIT🔥] Pin gerald at a specific tag version

### DIFF
--- a/.changeset/nervous-owls-grin.md
+++ b/.changeset/nervous-owls-grin.md
@@ -1,0 +1,5 @@
+---
+"gerald-pr": major
+---
+
+Pin gerald to a specific release so we can update gerald and not break actions until they've been udpated too

--- a/actions/gerald-pr/action.yml
+++ b/actions/gerald-pr/action.yml
@@ -25,7 +25,7 @@ runs:
           ref: '${{ github.head_ref }}'
         if: ${{ github.event.pull_request.draft == false }}
       - name: Run Gerald
-        uses: Khan/gerald@main
+        uses: Khan/gerald@2.0.0
         env:
           GITHUB_TOKEN: '${{ inputs.token }}'
           ADMIN_PERMISSION_TOKEN: '${{ inputs.admin-token }}'


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I updated gerald and actions started breaking. I suspect it's because these actions use `gerald@main` instead of a specific tag version. This PR pins gerald to a specific tag version.

Issue: FEI-4813

## Test plan:
Do a release and update workflows to hopefully see things working again.