### PR TITLE
Fix the issue of keeper not installing correctly on the latest macOS

### DIFF
--- a/.changeset/sharp-eggs-sneeze.md
+++ b/.changeset/sharp-eggs-sneeze.md
@@ -1,0 +1,5 @@
+---
+"setup-keeper": patch
+---
+
+version lock python & pip version that works with keeper installation instead of relying on the python version of the github runner image.

--- a/actions/setup-keeper/CHANGELOG.md
+++ b/actions/setup-keeper/CHANGELOG.md
@@ -1,7 +1,5 @@
 # setup-keeper
 
-## 1.0.1
-- version lock python & pip version that works with keeper installation instead of relying on the python version of the github runner image.
 ## 1.0.0
 
 ### Major Changes

--- a/actions/setup-keeper/package.json
+++ b/actions/setup-keeper/package.json
@@ -1,4 +1,4 @@
 {
-    "name": "setup-keeper",
-    "version": "1.0.1"
+  "name": "setup-keeper",
+  "version": "1.0.0"
 }


### PR DESCRIPTION
## Summary:
After many attempts of poking and prodding to try to understand what the heck was going on..... (Sorry for the email spam...)
![image](https://user-images.githubusercontent.com/34088613/204625629-dbc7daff-9a3a-4774-8db6-844036f45f07.png)

The root cause of the issue was that the github runner uses the image `macOS-latest`, this was pointing to `macOS-10` but Github changed `macOS-latest` to start pointing at `macOS-11`. This caused the system version of python and pip to change. This is when our keeper command started to break (keeper command not found, configs not loading). I attempted many potential solutions to get it to work.

1. Exporting the executable path of where the pip was installing keeper
2. A variety of ways to pass the configs to keeper documented here https://docs.keeper.io/secrets-manager/commander-cli/using-commander/logging-in
3. upgrading versions of our libraries

I was unable to get it to work with the system version of python (it was starting to get hacky with all the exporting and directory/symlink finagling) and decided I spent enough time trying to make it work. Ultimately I decided to version lock our python and pip so that we are not dependent on whatever python version the `macOS-latest` runs on. This will prevent this from github actions breaking because the version of python/pip has changed, and instead we can deliberately upgrade when we want to.

@jaredly is this the right way to update the github action? I need to tag and publish it and then create a PR in mobile to point to the new tag of this action.

Issue: MOB-4781

## Test plan:
![image](https://user-images.githubusercontent.com/34088613/204629276-07b3163a-2978-4343-aeaa-00988789bf41.png)
