### PR TITLE
Allow check-for-changeset to be configured to exclude files by extension

### DIFF
--- a/.changeset/rich-waves-refuse.md
+++ b/.changeset/rich-waves-refuse.md
@@ -1,0 +1,5 @@
+---
+"filter-files": minor
+---
+
+Add 'extensions' and 'globs' options to filter-files action for more flexibility

--- a/.changeset/spotty-jeans-agree.md
+++ b/.changeset/spotty-jeans-agree.md
@@ -1,0 +1,5 @@
+---
+"check-for-changeset": minor
+---
+
+Add more ways to exclude files from check-for-changeset (extensions and globs)

--- a/actions/check-for-changeset/action.yml
+++ b/actions/check-for-changeset/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: a list of comma-separated extensions that don't need a changeset when changed. Default <empty>
     required: false
     default: ''
+  exclude_glob:
+    description: a list of comma-separated globs (using picomatch syntax) that don't need a changeset when changed. Default <empty>
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -23,7 +27,7 @@ runs:
         invert: true
         files: ${{ inputs.exclude }}
         extensions: $${{ inputs.exclude_extensions }}
-        file_globs: ${{ inputs.exclude_glob }}
+        globs: ${{ inputs.exclude_glob }}
 
     - uses: actions/github-script@v6
       with:

--- a/actions/check-for-changeset/action.yml
+++ b/actions/check-for-changeset/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: a list of comma-separated extensions that don't need a changeset when changed. Default <empty>
     required: false
     default: ''
-  exclude_glob:
+  exclude_globs:
     description: a list of comma-separated globs (using picomatch syntax) that don't need a changeset when changed. Default <empty>
     required: false
     default: ''
@@ -27,7 +27,7 @@ runs:
         invert: true
         files: ${{ inputs.exclude }}
         extensions: $${{ inputs.exclude_extensions }}
-        globs: ${{ inputs.exclude_glob }}
+        globs: ${{ inputs.exclude_globs }}
 
     - uses: actions/github-script@v6
       with:

--- a/actions/check-for-changeset/action.yml
+++ b/actions/check-for-changeset/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: list of comma-separated paths (files or directories ending in /) that don't need a changeset when changed. Default .github/
     required: false
     default: .github/
+  exclude_extensions:
+    description: a list of comma-separated extensions that don't need a changeset when changed. Default <empty>
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -18,6 +22,8 @@ runs:
         changed-files: ${{ steps.changed.outputs.files }}
         invert: true
         files: ${{ inputs.exclude }}
+        extensions: $${{ inputs.exclude_extensions }}
+        file_globs: ${{ inputs.exclude_glob }}
 
     - uses: actions/github-script@v6
       with:

--- a/actions/check-for-changeset/package.json
+++ b/actions/check-for-changeset/package.json
@@ -1,4 +1,4 @@
 {
     "name": "check-for-changeset",
-    "version": "0.2.0"
+    "version": "0.1.0"
 }

--- a/actions/check-for-changeset/package.json
+++ b/actions/check-for-changeset/package.json
@@ -1,4 +1,4 @@
 {
     "name": "check-for-changeset",
-    "version": "0.1.0"
+    "version": "0.2.0"
 }

--- a/actions/filter-files/action.yml
+++ b/actions/filter-files/action.yml
@@ -10,6 +10,9 @@ inputs:
   extensions:
     description: 'comma- or newline-separated list of extensions to check for'
     required: false
+  globs:
+    description: 'comma- or newline-separated list of globs (using picomatch syntax) to check for'
+    required: false
   invert:
     description: 'if true, return the non-matched paths instead of the matched ones.'
     required: false
@@ -26,6 +29,7 @@ runs:
         script: |
           const extensionsRaw = `${{ inputs.extensions }}`;
           const exactFilesRaw = `${{ inputs.files }}`;
+          const globsRaw = `${{ inputs.globs }}`;
           const inputFilesRaw = `${{ inputs.changed-files }}`;
           if (inputFilesRaw.trim() === '') {
             throw new Error(`filter-files was called with an empty string as the "changed-files" parameter.`)
@@ -33,5 +37,5 @@ runs:
           const inputFiles = JSON.parse(inputFilesRaw);
           const invert = `${{ inputs.invert }}` == 'true';
 
-          return require('./actions/filter-files/index.js')({extensionsRaw, exactFilesRaw, inputFiles, invert, core})
+          return require('./actions/filter-files/index.js')({extensionsRaw, exactFilesRaw, globsRaw, inputFiles, invert, core})
         result-encoding: json

--- a/actions/filter-files/index.js
+++ b/actions/filter-files/index.js
@@ -1,3 +1,5 @@
+const picomatch = require("picomatch");
+
 /**
  * Parse a list, that could be separated by commas or newlines.
  */
@@ -11,15 +13,24 @@ const parseList = (raw) => {
     return raw.split("\n").map((item) => item.trim());
 };
 
-module.exports = ({extensionsRaw, exactFilesRaw, inputFiles, invert, core}) => {
+module.exports = ({
+    extensionsRaw,
+    exactFilesRaw,
+    globsRaw,
+    inputFiles,
+    invert,
+    core,
+}) => {
     const extensions = parseList(extensionsRaw);
     const exactFiles = parseList(exactFilesRaw);
+    const globMather = picomatch(parseList(globsRaw));
     const directories = exactFiles.filter((name) => name.endsWith("/"));
     const result = inputFiles.filter((name) => {
         const matched =
             extensions.some((ext) => name.endsWith(ext)) ||
             exactFiles.includes(name) ||
-            directories.some((dir) => name.startsWith(dir));
+            directories.some((dir) => name.startsWith(dir)) ||
+            globMather(name);
         return matched === !invert;
     });
     core.info(`Filtered Files: ${JSON.stringify(result)}`);

--- a/actions/filter-files/package.json
+++ b/actions/filter-files/package.json
@@ -1,4 +1,7 @@
 {
     "name": "filter-files",
-    "version": "0.2.1"
+    "version": "0.2.1",
+    "dependencies": {
+        "picomatch": "2"
+    }
 }

--- a/actions/filter-files/package.json
+++ b/actions/filter-files/package.json
@@ -1,6 +1,6 @@
 {
     "name": "filter-files",
-    "version": "0.2.1",
+    "version": "0.3.0",
     "dependencies": {
         "picomatch": "2"
     }

--- a/actions/filter-files/package.json
+++ b/actions/filter-files/package.json
@@ -1,6 +1,6 @@
 {
     "name": "filter-files",
-    "version": "0.3.0",
+    "version": "0.2.1",
     "dependencies": {
         "picomatch": "2"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2786,7 +2786,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@2, picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==


### PR DESCRIPTION
## Summary:

The check-for-changeset action is really useful in making sure we don't put up a PR without a `.changeset/*` file. But it often flags PRs that we can guarantee don't need a changeset (for example, a test-only PR or one that just touches Storybook stories). 

This PR adds the ability to filter out entire classes of files by extension (*.test.js or *.stories.js) for example. 

We will still need to configure each repo that uses this action to exclude the files by extension, but this opens the door for those configurations.

Issue: "none"

## Test plan:

Use the action in this PR in a repo (Khan/perseus, for example) and create a PR that contains changes only to files with extensions we configure to exclude.