### PR TITLE
Support JS-based actions having dependencies

### DIFF
--- a/.changeset/rich-waves-refuse.md
+++ b/.changeset/rich-waves-refuse.md
@@ -1,0 +1,5 @@
+---
+"filter-files": minor
+---
+
+Add 'extensions' and 'globs' options to filter-files action for more flexibility

--- a/.changeset/spotty-jeans-agree.md
+++ b/.changeset/spotty-jeans-agree.md
@@ -1,0 +1,5 @@
+---
+"check-for-changeset": minor
+---
+
+Add more ways to exclude files from check-for-changeset (extensions and globs)

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,4 +26,12 @@ module.exports = {
         sourceType: "module",
         ecmaVersion: 2022,
     },
+    overrides: [
+        {
+            files: "utils/*",
+            rules: {
+                "no-console": "off",
+            },
+        },
+    ],
 };

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/actions/check-for-changeset/action.yml
+++ b/actions/check-for-changeset/action.yml
@@ -5,6 +5,14 @@ inputs:
     description: list of comma-separated paths (files or directories ending in /) that don't need a changeset when changed. Default .github/
     required: false
     default: .github/
+  exclude_extensions:
+    description: a list of comma-separated extensions that don't need a changeset when changed. Default <empty>
+    required: false
+    default: ''
+  exclude_globs:
+    description: a list of comma-separated globs (using picomatch syntax) that don't need a changeset when changed. Default <empty>
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -18,6 +26,8 @@ runs:
         changed-files: ${{ steps.changed.outputs.files }}
         invert: true
         files: ${{ inputs.exclude }}
+        extensions: $${{ inputs.exclude_extensions }}
+        globs: ${{ inputs.exclude_globs }}
 
     - uses: actions/github-script@v6
       with:

--- a/actions/check-for-changeset/package.json
+++ b/actions/check-for-changeset/package.json
@@ -1,4 +1,4 @@
 {
     "name": "check-for-changeset",
-    "version": "0.1.0"
+    "version": "0.2.0"
 }

--- a/actions/filter-files/action.yml
+++ b/actions/filter-files/action.yml
@@ -10,6 +10,9 @@ inputs:
   extensions:
     description: 'comma- or newline-separated list of extensions to check for'
     required: false
+  globs:
+    description: 'comma- or newline-separated list of globs (using picomatch syntax) to check for'
+    required: false
   invert:
     description: 'if true, return the non-matched paths instead of the matched ones.'
     required: false
@@ -26,6 +29,7 @@ runs:
         script: |
           const extensionsRaw = `${{ inputs.extensions }}`;
           const exactFilesRaw = `${{ inputs.files }}`;
+          const globsRaw = `${{ inputs.globs }}`;
           const inputFilesRaw = `${{ inputs.changed-files }}`;
           if (inputFilesRaw.trim() === '') {
             throw new Error(`filter-files was called with an empty string as the "changed-files" parameter.`)
@@ -33,5 +37,5 @@ runs:
           const inputFiles = JSON.parse(inputFilesRaw);
           const invert = `${{ inputs.invert }}` == 'true';
 
-          return require('./actions/filter-files/index.js')({extensionsRaw, exactFilesRaw, inputFiles, invert, core})
+          return require('./actions/filter-files/index.js')({extensionsRaw, exactFilesRaw, globsRaw, inputFiles, invert, core})
         result-encoding: json

--- a/actions/filter-files/index.js
+++ b/actions/filter-files/index.js
@@ -1,3 +1,5 @@
+const picomatch = require("picomatch");
+
 /**
  * Parse a list, that could be separated by commas or newlines.
  */
@@ -11,15 +13,24 @@ const parseList = (raw) => {
     return raw.split("\n").map((item) => item.trim());
 };
 
-module.exports = ({extensionsRaw, exactFilesRaw, inputFiles, invert, core}) => {
+module.exports = ({
+    extensionsRaw,
+    exactFilesRaw,
+    globsRaw,
+    inputFiles,
+    invert,
+    core,
+}) => {
     const extensions = parseList(extensionsRaw);
     const exactFiles = parseList(exactFilesRaw);
+    const globMather = picomatch(parseList(globsRaw));
     const directories = exactFiles.filter((name) => name.endsWith("/"));
     const result = inputFiles.filter((name) => {
         const matched =
             extensions.some((ext) => name.endsWith(ext)) ||
             exactFiles.includes(name) ||
-            directories.some((dir) => name.startsWith(dir));
+            directories.some((dir) => name.startsWith(dir)) ||
+            globMather(name);
         return matched === !invert;
     });
     core.info(`Filtered Files: ${JSON.stringify(result)}`);

--- a/actions/filter-files/index.js
+++ b/actions/filter-files/index.js
@@ -23,14 +23,14 @@ module.exports = ({
 }) => {
     const extensions = parseList(extensionsRaw);
     const exactFiles = parseList(exactFilesRaw);
-    const globMather = picomatch(parseList(globsRaw));
+    const globMatcher = picomatch(parseList(globsRaw));
     const directories = exactFiles.filter((name) => name.endsWith("/"));
     const result = inputFiles.filter((name) => {
         const matched =
             extensions.some((ext) => name.endsWith(ext)) ||
             exactFiles.includes(name) ||
             directories.some((dir) => name.startsWith(dir)) ||
-            globMather(name);
+            globMatcher(name);
         return matched === !invert;
     });
     core.info(`Filtered Files: ${JSON.stringify(result)}`);

--- a/actions/filter-files/package.json
+++ b/actions/filter-files/package.json
@@ -1,4 +1,7 @@
 {
     "name": "filter-files",
-    "version": "0.2.1"
+    "version": "0.2.1",
+    "dependencies": {
+        "picomatch": "2"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "devDependencies": {
         "@changesets/cli": "^2.22.0",
         "@khanacademy/eslint-config": "^0.1.0",
+        "@vercel/ncc": "^0.36.1",
         "eslint": "^8.15.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.0.0",

--- a/utils/build.mjs
+++ b/utils/build.mjs
@@ -78,8 +78,12 @@ export const buildPackage = (name, packageJsons, monorepoName) => {
     // existing output file.
     if (fs.existsSync(`${dist}/index.js`)) {
         fs.rmSync(`${dist}/index.js`, {force: true});
+    }
+
+    if (fs.existsSync(`actions/${name}/index.js`)) {
+        console.log(`Building actions/${name}/index.js`);
         execSync(
-            `yarn ncc build actions/${name}/index.js -o ${dist}/index.js --source-map`,
+            `yarn ncc build actions/${name}/index.js -o ${dist} --source-map`,
         );
     }
 

--- a/utils/build.mjs
+++ b/utils/build.mjs
@@ -41,10 +41,15 @@ export const processActionYml = (
         },
     ];
     Object.keys(packageJsons[name].dependencies ?? {}).forEach((depName) => {
-        replacements.push({
-            from: new RegExp(`\\buses: \\./actions/${depName}\\b`, "g"),
-            to: `uses: ${monorepoName}@${depName}-v${packageJsons[depName].version}`,
-        });
+        console.log("Processing dependency:", depName);
+        if (depName in packageJsons) {
+            replacements.push({
+                from: new RegExp(`\\buses: \\./actions/${depName}\\b`, "g"),
+                to: `uses: ${monorepoName}@${depName}-v${packageJsons[depName].version}`,
+            });
+        } else {
+            console.log("   Skipping (external dependency)");
+        }
     });
     replacements.forEach(({from, to}) => {
         actionYml = actionYml.replace(from, to);

--- a/utils/publish.mjs
+++ b/utils/publish.mjs
@@ -58,6 +58,8 @@ export const collectPackageJsons = (packageNames) => {
 };
 
 export const publishAsNeeded = (packageNames, dryRun = false) => {
+    console.log(`Publishing (${dryRun ? "dry run" : "for real"})...`);
+
     // Because we rewrite our major version tags (filter-files-v1 for example)
     // on every patch & minor version publish, tags will move around, and -f
     // is needed if you have different tags locally.
@@ -66,7 +68,6 @@ export const publishAsNeeded = (packageNames, dryRun = false) => {
         encoding: "utf8",
     }).trim();
     const packageJsons = collectPackageJsons(packageNames);
-
     packageNames.forEach((name) => {
         const version = packageJsons[name].version;
         const majorVersion = version.split(".")[0];

--- a/yarn.lock
+++ b/yarn.lock
@@ -2786,7 +2786,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
+picomatch@2, picomatch@^2.0.4, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -948,6 +948,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@vercel/ncc@^0.36.1":
+  version "0.36.1"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.36.1.tgz#d4c01fdbbe909d128d1bf11c7f8b5431654c5b95"
+  integrity sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"


### PR DESCRIPTION
## Summary:

In the last Version Packages PR I had a change that added a npm dependency to one of the JS-based actions in this repo and that [broke](https://github.com/Khan/actions/actions/runs/4963419816/jobs/8882640617) the publish step!  We currently don't support this and so the publish step failed for (for two reasons actually):

  1. Our build script assumes that all `dependencies` in our actions `package.json` are a cross-reference to another action in this repo
  2. We don't have any bundling setup so our JS actions are copied as-is into the `dist` folder that we publish

This PR addresses both of these issues by:
  1. We don't try to process depedencies in action YML files for external deps
  2. Set up ncc to build JS packages on publish (following Github [JS action template](https://github.com/actions/javascript-action/blob/main/package.json#L8))

Issue: "none"

## Test plan:

I've tested the build using `node utils/run-publish.mjs --dry-run` and it seems to build the files into the `dist` folders correctly.