### PR TITLE
[🔥AUDIT🔥] Fix exclude_extensions in check-for-changeset action call

### DIFF
--- a/.changeset/spotty-kangaroos-glow.md
+++ b/.changeset/spotty-kangaroos-glow.md
@@ -1,0 +1,5 @@
+---
+"check-for-changeset": minor
+---
+
+Fix how extensions are parsed so that it doesn't break them

--- a/actions/check-for-changeset/action.yml
+++ b/actions/check-for-changeset/action.yml
@@ -26,7 +26,7 @@ runs:
         changed-files: ${{ steps.changed.outputs.files }}
         invert: true
         files: ${{ inputs.exclude }}
-        extensions: $${{ inputs.exclude_extensions }}
+        extensions: ${{ inputs.exclude_extensions }}
         globs: ${{ inputs.exclude_globs }}
 
     - uses: actions/github-script@v6


### PR DESCRIPTION
## Summary:

When I added the `exclude_extensions` parameter to the `check-for-changeset` action.yml, I accidentally had two dollar signs when accessing the `exclude_extensions` input parameter (ie. `$${{ input.exclude_extensions }}`). This then caused the `check-for-changeset` to complain about changesets when it shouldn't ([here](https://github.com/Khan/perseus/actions/runs/4985308846/jobs/8924746558?pr=531))

This caused the call to `filter-files` to have an `extensions` value that always started with a dollar sign, which in turn caused the provided extension list to not match if the file _would have_ matched the first extension in the list (because the `filter-files` action got a list of extensions that looked like this: `['$.ext1', '.ext2', '.ext3']`. 

Issue: "none"

## Test plan:

I'll land this and publish and then test again in Perseus.