### PR TITLE
[🔥AUDIT🔥] Try to fix our publish script

### DIFF
--- a/.changeset/selfish-spoons-retire.md
+++ b/.changeset/selfish-spoons-retire.md
@@ -1,0 +1,5 @@
+---
+"shared-node-cache": patch
+---
+
+A trivial change to test our publishing

--- a/actions/shared-node-cache/action.yml
+++ b/actions/shared-node-cache/action.yml
@@ -8,7 +8,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-
     - name: Use Node.js ${{ inputs.node-version }}
       uses: actions/setup-node@v3
       with:

--- a/utils/publish.mjs
+++ b/utils/publish.mjs
@@ -40,6 +40,7 @@ export const publishDirectoryAsTags = (
         // This will succeed with a warning if the major tag doesn't exist
         cmds.push(`git push origin :refs/tags/${majorTag}`);
         cmds.push(`git push origin ${majorTag}`);
+        cmds.push(`git push origin --tags`);
     }
     cmds.forEach((cmd) => {
         execSync(cmd, {cwd: distPath});


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
It has been publishing our actions correctly, but then the `changesets/action` fails, and so the "github action" technically errors out (see https://github.com/Khan/actions/actions/runs/4982973373/jobs/8919388693)
It would be nice for that not to be the case.

The thing that's happening is the changesets/action tries to `git push origin --tags`, and that's failing for some reason. I'll try doing it already within our script, to see if any good will come of it.

Issue: XXX-XXXX

## Test plan: