### PR TITLE
Downgrade keepercommander to 16.5.6

### DIFF
--- a/actions/setup-keeper/action.yml
+++ b/actions/setup-keeper/action.yml
@@ -14,7 +14,7 @@ runs:
       shell: bash
       run: |
         python3 -m pip install --upgrade pip==22.2.2
-        python3 -m pip install cryptography==37.0.2 pyOpenSSL==22.0.0 keepercommander==16.6.5
+        python3 -m pip install cryptography==37.0.2 pyOpenSSL==22.0.0 keepercommander==16.5.6
 
     - uses: actions/github-script@v6
       with:


### PR DESCRIPTION
## Summary:
Keeper is throttling our API calls, preventing our GitHub Actions from
deploying ZNDs for webapp PRs. See this Slack thread for discussion:

https://khanacademy.slack.com/archives/C02NMB1R5/p1685030740156649

Downgrading keepercommander seems to fix the throttling issue, somehow.

Issue: none

## Test plan:

In `static-service-pr-e2e.yml` in webapp, change references to the
`setup-keeper-v1.0.0` tag to `setup-keeper-v1.1.0`. Re-run the e2e tests on a
PR where they're failing due to the throttling issue.  The ZND for testing
should be successfully deployed.