### PR TITLE
Upgrade keepercommander to 16.5.16

### DIFF
--- a/.changeset/good-snails-walk.md
+++ b/.changeset/good-snails-walk.md
@@ -1,0 +1,5 @@
+---
+"setup-keeper": minor
+---
+
+Upgrade keepercommander to 16.5.16

--- a/actions/setup-keeper/action.yml
+++ b/actions/setup-keeper/action.yml
@@ -14,7 +14,7 @@ runs:
       shell: bash
       run: |
         python3 -m pip install --upgrade pip==22.2.2
-        python3 -m pip install cryptography==37.0.2 pyOpenSSL==22.0.0 keepercommander==16.5.6
+        python3 -m pip install cryptography==37.0.2 pyOpenSSL==22.0.0 keepercommander==16.5.16
 
     - uses: actions/github-script@v6
       with:


### PR DESCRIPTION
## Summary:
Keeper is throttling our API calls, preventing our GitHub Actions from
deploying ZNDs for webapp PRs. See this Slack thread for discussion:

https://khanacademy.slack.com/archives/C02NMB1R5/p1685030740156649

Changing the keepercommander version seems to fix the throttling issue,
somehow.

Note: the previous release of setup-keeper, 1.1.0, changed the version
of keepercommander to 16.5.6. That was due to a miscommunication; 16.5.6
will not work in webapp. During the "Deploy static version to GCS" step
of running E2E tests, we get this error:

```
KeeperError: keeper version 16.5.6 is too old, see https://khanacademy.org/r/keeper-cli for assistance
at _verifyKeeperInstallation (/home/runner/work/webapp/webapp/services/static/dev/tools/utils/map-keeper-records.js:75:15)
```

Issue: none

Run the build on this pull request:
https://github.com/Khan/webapp/pull/14127

## Test plan: