### PR TITLE
Bump keeper to 16.7.10

### DIFF
--- a/actions/setup-keeper/action.yml
+++ b/actions/setup-keeper/action.yml
@@ -14,7 +14,7 @@ runs:
       shell: bash
       run: |
         python3 -m pip install --upgrade pip==22.2.2
-        python3 -m pip install cryptography==37.0.2 pyOpenSSL==22.0.0 keepercommander==16.5.16
+        python3 -m pip install cryptography==37.0.2 pyOpenSSL==22.0.0 keepercommander==16.7.10
 
     - uses: actions/github-script@v6
       with:


### PR DESCRIPTION
## Summary:
This is an attemp to address communication issues we're seeing with the current version.

Issue: None

## Test plan:
- update https://github.com/Khan/webapp/pull/15572 to use the new version of this action