### PR TITLE
Remove superfluous input

### DIFF
--- a/.changeset/twenty-cougars-remain.md
+++ b/.changeset/twenty-cougars-remain.md
@@ -1,0 +1,5 @@
+---
+"get-changed-files": minor
+---
+
+Removed "required" token input. It is not used, and creates non-blocking parsing errors for consumers using Github Actions plugin.

--- a/actions/get-changed-files/action.yml
+++ b/actions/get-changed-files/action.yml
@@ -1,9 +1,6 @@
 name: Get Changed Files
 description: Get a list of the files that have change in this pull-request or push
 inputs:
-  token:
-    description: secrets.GITHUB_TOKEN
-    required: true
   directories:
     description: Prefilter results to only the listed subdirectories (newline-separated)
     required: false


### PR DESCRIPTION
`token` input is unused, but marked `required`. This creates some noisy red underlines in consuming workflows that use the Github Actions extension.

![Screenshot 2023-09-21 at 4 52 14 PM](https://github.com/Khan/actions/assets/23404711/2661058e-962e-4002-bd1d-f41828d6820e)
