### PR TITLE
Allow Conjunctive Filter (all true, vs current any true)

### DIFF
--- a/.changeset/selfish-cheetahs-compare.md
+++ b/.changeset/selfish-cheetahs-compare.md
@@ -1,0 +1,5 @@
+---
+"filter-files": minor
+---
+
+Added optional parameter to assert that _every_ filter condition passes to include a file. This switches from an inclusive disjunction to conjunction.

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -49,23 +49,23 @@ jobs:
           script: |
             const fftest1 = `${{ steps.fftest1.outputs.filtered }}`;
             if (fftest1 !== `["one","two"]`) {
-              core.setFailed(fftest1)
+              core.setFailed('fftest1: ' + fftest1)
             }
             const fftest2 = `${{ steps.fftest2.outputs.filtered }}`;
             if (fftest2 !== `["two/three"]`) {
-              core.setFailed(fftest2)
+              core.setFailed('fftest2: ' + fftest2)
             }
             const fftest3 = `${{ steps.fftest3.outputs.filtered }}`;
             if (fftest3 !== `["one.ts","three.js"]`) {
-              core.setFailed(fftest3)
+              core.setFailed('fftest3: ' + fftest3)
             }
             const fftest4 = `${{ steps.fftest4.outputs.filtered }}`;
             if (fftest4 !== `["two/three"]`) {
-              core.setFailed(fftest4)
+              core.setFailed('fftest4: ' + fftest4)
             }
             const fftest5 = `${{ steps.fftest5.outputs.filtered }}`;
             if (fftest5 !== `["one","two/three/four"]`) {
-              core.setFailed(fftest5)
+              core.setFailed('fftest5: ' + fftest5)
             }
 
       - uses: ./actions/get-changed-files

--- a/actions/filter-files/action.yml
+++ b/actions/filter-files/action.yml
@@ -1,46 +1,46 @@
-name: "Filter files please"
-description: "Filter the list of changed files"
+name: 'Filter files please'
+description: 'Filter the list of changed files'
 inputs:
-    changed-files:
-        description: "jsonified list of changed files"
-        required: true
-    files:
-        description: 'comma- or newline-separated list of files to match against. names ending in "/" will be treated as a directory path, and match as a prefix. Otherwise path names must be a full match.'
-        required: false
-    extensions:
-        description: "comma- or newline-separated list of extensions to check for"
-        required: false
-    globs:
-        description: "comma- or newline-separated list of globs (using picomatch syntax) to check for"
-        required: false
-    invert:
-        description: "if true, return the non-matched paths instead of the matched ones."
-        required: false
-    conjunctive:
-        description: "if true, return only the files that match all of the criteria. Otherwise, return files that match any of the criteria."
-        required: false
-        default: false
+  changed-files:
+    description: 'jsonified list of changed files'
+    required: true
+  files:
+    description: 'comma- or newline-separated list of files to match against. names ending in "/" will be treated as a directory path, and match as a prefix. Otherwise path names must be a full match.'
+    required: false
+  extensions:
+    description: 'comma- or newline-separated list of extensions to check for'
+    required: false
+  globs:
+    description: 'comma- or newline-separated list of globs (using picomatch syntax) to check for'
+    required: false
+  invert:
+    description: 'if true, return the non-matched paths instead of the matched ones.'
+    required: false
+  conjunctive:
+    description: 'if true, return only the files that match all of the criteria. Otherwise, return files that match any of the criteria.'
+    required: false
+    default: false
 outputs:
-    filtered:
-        description: "The jsonified list of files that match"
-        value: ${{ steps.result.outputs.result }}
+  filtered:
+    description: 'The jsonified list of files that match'
+    value: ${{ steps.result.outputs.result }}
 runs:
-    using: "composite"
-    steps:
-        - uses: actions/github-script@v6
-          id: result
-          with:
-              script: |
-                  const extensionsRaw = `${{ inputs.extensions }}`;
-                  const exactFilesRaw = `${{ inputs.files }}`;
-                  const globsRaw = `${{ inputs.globs }}`;
-                  const inputFilesRaw = `${{ inputs.changed-files }}`;
-                  if (inputFilesRaw.trim() === '') {
-                    throw new Error(`filter-files was called with an empty string as the "changed-files" parameter.`)
-                  }
-                  const inputFiles = JSON.parse(inputFilesRaw);
-                  const invert = `${{ inputs.invert }}` == 'true';
-                  const conjunctive = `${{ inputs.conjunctive }}` == 'true';
+  using: "composite"
+  steps:
+    - uses: actions/github-script@v6
+      id: result
+      with:
+        script: |
+          const extensionsRaw = `${{ inputs.extensions }}`;
+          const exactFilesRaw = `${{ inputs.files }}`;
+          const globsRaw = `${{ inputs.globs }}`;
+          const inputFilesRaw = `${{ inputs.changed-files }}`;
+          if (inputFilesRaw.trim() === '') {
+            throw new Error(`filter-files was called with an empty string as the "changed-files" parameter.`)
+          }
+          const inputFiles = JSON.parse(inputFilesRaw);
+          const invert = `${{ inputs.invert }}` == 'true';
+          const conjunctive = `${{ inputs.conjunctive }}` == 'true';
 
-                  return require('./actions/filter-files/index.js')({extensionsRaw, exactFilesRaw, globsRaw, inputFiles, invert, conjunctive, core})
-              result-encoding: json
+          return require('./actions/filter-files/index.js')({extensionsRaw, exactFilesRaw, globsRaw, inputFiles, invert, conjunctive, core})
+        result-encoding: json

--- a/actions/filter-files/action.yml
+++ b/actions/filter-files/action.yml
@@ -1,41 +1,46 @@
-name: 'Filter files please'
-description: 'Filter the list of changed files'
+name: "Filter files please"
+description: "Filter the list of changed files"
 inputs:
-  changed-files:
-    description: 'jsonified list of changed files'
-    required: true
-  files:
-    description: 'comma- or newline-separated list of files to match against. names ending in "/" will be treated as a directory path, and match as a prefix. Otherwise path names must be a full match.'
-    required: false
-  extensions:
-    description: 'comma- or newline-separated list of extensions to check for'
-    required: false
-  globs:
-    description: 'comma- or newline-separated list of globs (using picomatch syntax) to check for'
-    required: false
-  invert:
-    description: 'if true, return the non-matched paths instead of the matched ones.'
-    required: false
+    changed-files:
+        description: "jsonified list of changed files"
+        required: true
+    files:
+        description: 'comma- or newline-separated list of files to match against. names ending in "/" will be treated as a directory path, and match as a prefix. Otherwise path names must be a full match.'
+        required: false
+    extensions:
+        description: "comma- or newline-separated list of extensions to check for"
+        required: false
+    globs:
+        description: "comma- or newline-separated list of globs (using picomatch syntax) to check for"
+        required: false
+    invert:
+        description: "if true, return the non-matched paths instead of the matched ones."
+        required: false
+    conjunctive:
+        description: "if true, return only the files that match all of the criteria. Otherwise, return files that match any of the criteria."
+        required: false
+        default: false
 outputs:
-  filtered:
-    description: 'The jsonified list of files that match'
-    value: ${{ steps.result.outputs.result }}
+    filtered:
+        description: "The jsonified list of files that match"
+        value: ${{ steps.result.outputs.result }}
 runs:
-  using: "composite"
-  steps:
-    - uses: actions/github-script@v6
-      id: result
-      with:
-        script: |
-          const extensionsRaw = `${{ inputs.extensions }}`;
-          const exactFilesRaw = `${{ inputs.files }}`;
-          const globsRaw = `${{ inputs.globs }}`;
-          const inputFilesRaw = `${{ inputs.changed-files }}`;
-          if (inputFilesRaw.trim() === '') {
-            throw new Error(`filter-files was called with an empty string as the "changed-files" parameter.`)
-          }
-          const inputFiles = JSON.parse(inputFilesRaw);
-          const invert = `${{ inputs.invert }}` == 'true';
+    using: "composite"
+    steps:
+        - uses: actions/github-script@v6
+          id: result
+          with:
+              script: |
+                  const extensionsRaw = `${{ inputs.extensions }}`;
+                  const exactFilesRaw = `${{ inputs.files }}`;
+                  const globsRaw = `${{ inputs.globs }}`;
+                  const inputFilesRaw = `${{ inputs.changed-files }}`;
+                  if (inputFilesRaw.trim() === '') {
+                    throw new Error(`filter-files was called with an empty string as the "changed-files" parameter.`)
+                  }
+                  const inputFiles = JSON.parse(inputFilesRaw);
+                  const invert = `${{ inputs.invert }}` == 'true';
+                  const conjunctive = `${{ inputs.conjunctive }}` == 'true';
 
-          return require('./actions/filter-files/index.js')({extensionsRaw, exactFilesRaw, globsRaw, inputFiles, invert, core})
-        result-encoding: json
+                  return require('./actions/filter-files/index.js')({extensionsRaw, exactFilesRaw, globsRaw, inputFiles, invert, conjunctive, core})
+              result-encoding: json

--- a/actions/filter-files/action.yml
+++ b/actions/filter-files/action.yml
@@ -40,8 +40,8 @@ runs:
             throw new Error(`filter-files was called with an empty string as the "changed-files" parameter.`)
           }
           const inputFiles = JSON.parse(inputFilesRaw);
-          const invert = `${{ inputs.invert }}`;
-          const conjunctive = `${{ inputs.conjunctive }}`;
+          const invert = ${{ inputs.invert == 'true' }};
+          const conjunctive = ${{ inputs.conjunctive == 'true' }};
 
           return require('./actions/filter-files/index.js')({extensionsRaw, exactFilesRaw, globsRaw, inputFiles, invert, conjunctive, core})
         result-encoding: json

--- a/actions/filter-files/action.yml
+++ b/actions/filter-files/action.yml
@@ -16,6 +16,7 @@ inputs:
   invert:
     description: 'if true, return the non-matched paths instead of the matched ones.'
     required: false
+    default: false
   conjunctive:
     description: 'if true, return only the files that match all of the criteria. Otherwise, return files that match any of the criteria.'
     required: false
@@ -39,8 +40,8 @@ runs:
             throw new Error(`filter-files was called with an empty string as the "changed-files" parameter.`)
           }
           const inputFiles = JSON.parse(inputFilesRaw);
-          const invert = `${{ inputs.invert }}` == 'true';
-          const conjunctive = `${{ inputs.conjunctive }}` == 'true';
+          const invert = `${{ inputs.invert }}`;
+          const conjunctive = `${{ inputs.conjunctive }}`;
 
           return require('./actions/filter-files/index.js')({extensionsRaw, exactFilesRaw, globsRaw, inputFiles, invert, conjunctive, core})
         result-encoding: json

--- a/actions/filter-files/filter-files.test.mjs
+++ b/actions/filter-files/filter-files.test.mjs
@@ -1,12 +1,11 @@
 import filterFiles from ".";
 
 describe("filterFiles", () => {
-    // eslint-disable-next-line no-console
-    const core = {info: console.info};
-    const invert = true;
+    const core = console;
 
     it("should return a new array files that are not filtered", () => {
         // Arrange
+        const invert = true;
         const inputFiles = [
             ".github/workflows/test.yml",
             ".changeset/README.md",
@@ -49,6 +48,7 @@ describe("filterFiles", () => {
 
     it("should throw an error for unbalanced brackets", () => {
         // Arrange
+        const invert = true;
         const globsRaw =
             "!packages/**/*.{ts,tsx,js,jsx}}), packages/this-one.ts";
 
@@ -70,6 +70,7 @@ describe("filterFiles", () => {
         //   but it's a good way to check that we have exited early
 
         // Arrange
+        const invert = true;
         const globsRaw = `packages/**/*.ts,tsx,js,jsx}})
             packages/this-one.ts`;
 
@@ -89,6 +90,7 @@ describe("filterFiles", () => {
 
     it("should allow whitespace", () => {
         // Arrange
+        const invert = true;
         const exactFilesRaw = `sub dir/file1.txt, file 2.txt, file 3.txt`;
 
         // Act
@@ -103,5 +105,82 @@ describe("filterFiles", () => {
 
         // Assert
         expect(result).toEqual(["not filtered"]);
+    });
+
+    it("inclusive disjunction (OR) by default", () => {
+        // Arrange
+        const inputFiles = [
+            ".github/workflows/test.yml",
+            ".changeset/README.md",
+            "other/thing.ts",
+            "packages/core/src/index.ts",
+            "packages/core/src/index.test.ts",
+            "packages/core/src/index.jsx",
+            "packages/core/src/index.test.jsx",
+            "packages/core/src/styles.css",
+            "packages/this-one.ts",
+            "anything.ts",
+        ];
+        const expected = [
+            "other/thing.ts",
+            "packages/core/src/index.ts",
+            "packages/core/src/index.test.ts",
+            "packages/core/src/index.jsx",
+            "packages/core/src/index.test.jsx",
+            "packages/core/src/styles.css",
+            "packages/this-one.ts",
+            "anything.ts",
+        ];
+        const extensionsRaw = `ts,js,jsx,tsx`;
+        const exactFilesRaw = "packages/";
+        const globsRaw = "!(packages/**/*.test.*), packages/this-one.ts";
+
+        // Act
+        const result = filterFiles({
+            extensionsRaw,
+            exactFilesRaw,
+            globsRaw,
+            inputFiles,
+            core,
+        });
+
+        // Assert
+        expect(result).toEqual(expected);
+    });
+
+    it("conjunction (AND) when specified", () => {
+        // Arrange
+        const inputFiles = [
+            ".github/workflows/test.yml",
+            ".changeset/README.md",
+            "other/thing.ts",
+            "packages/core/src/index.ts",
+            "packages/core/src/index.test.ts",
+            "packages/core/src/index.jsx",
+            "packages/core/src/index.test.jsx",
+            "packages/core/src/styles.css",
+            "packages/this-one.ts",
+        ];
+        const expected = [
+            "packages/core/src/index.ts",
+            "packages/core/src/index.jsx",
+            "packages/this-one.ts",
+        ];
+        const extensionsRaw = `ts,js,jsx,tsx`;
+        const exactFilesRaw = "packages/";
+        const globsRaw = "!(packages/**/*.test.*), packages/this-one.ts";
+
+        // Act
+        const result = filterFiles({
+            inputFiles,
+            extensionsRaw,
+            exactFilesRaw,
+            globsRaw,
+            conjunctive: true,
+            core,
+        });
+
+        // Assert
+        expect(result).toEqual(expected);
     });
 });


### PR DESCRIPTION
Adds option to assert _all_ filters pass.

Currently, if any of the filters are true, the path is included in filtered files. This makes it difficult to use multiple filter types to refine our choice, especially when not in `invert` mode.

Now, we can designate some directories and file extensions and only files in those directories with those extensions will return.