### PR TITLE
Move to Node 20 being our default

### DIFF
--- a/.changeset/olive-eyes-pull.md
+++ b/.changeset/olive-eyes-pull.md
@@ -1,0 +1,5 @@
+---
+"shared-node-cache": major
+---
+
+Default to Node 20 instead of 16

--- a/actions/shared-node-cache/action.yml
+++ b/actions/shared-node-cache/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: 'Node version to use'
     required: false
-    default: '16.x'
+    default: '20.x'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Summary:
This changes the default node version for the shared-node-cache action to 20. Did this as a major bump so that repos that didn't specify a version other than the default aren't going to get a surprise bump to 20. That way we can do things repo-by-repo to head of any weird issues.

Issue: FEI-5413

## Test plan:
1. `yarn lint`
2. `yarn test`
3. Get this release published and then we can start using it in the repos I migrate to Node 20, and verify all is well.