### PR TITLE
Node v20 updates

### DIFF
--- a/.changeset/fluffy-trains-retire.md
+++ b/.changeset/fluffy-trains-retire.md
@@ -1,0 +1,10 @@
+---
+"gerald-pr": major
+"get-changed-files": major
+"shared-node-cache": major
+"check-for-changeset": minor
+"filter-files": minor
+"json-args": minor
+---
+
+Bump all used actions to versions that use Node v20 runtime

--- a/.github/workflows/gerald-pr.yml
+++ b/.github/workflows/gerald-pr.yml
@@ -9,7 +9,7 @@ jobs:
     if: "github.event.action != 'edited' || github.event.changes.base != null"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./actions/gerald-pr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: Lints
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./actions/shared-node-cache
       - run: yarn lint
 
@@ -43,7 +43,7 @@ jobs:
           files: 'two/three'
           invert: true
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         name: Test the 'filter-files' action
         with:
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./actions/shared-node-cache
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         id: has-changesets
         with:
           script: |

--- a/actions/check-for-changeset/action.yml
+++ b/actions/check-for-changeset/action.yml
@@ -29,7 +29,7 @@ runs:
         extensions: ${{ inputs.exclude_extensions }}
         globs: ${{ inputs.exclude_globs }}
 
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@v7
       with:
         script: |
           const inputFiles = JSON.parse(`${{ steps.match.outputs.filtered }}`);

--- a/actions/filter-files/action.yml
+++ b/actions/filter-files/action.yml
@@ -32,7 +32,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@v7
       id: result
       with:
         script: |

--- a/actions/gerald-pr/action.yml
+++ b/actions/gerald-pr/action.yml
@@ -15,12 +15,12 @@ runs:
         id: changed
         if: ${{ github.event.pull_request.draft == false }}
       - name: Check out base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: '${{ github.base_ref }}'
         if: ${{ github.event.pull_request.draft == false }}
       - name: Check out head branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: '${{ github.head_ref }}'
         if: ${{ github.event.pull_request.draft == false }}

--- a/actions/get-changed-files/action.yml
+++ b/actions/get-changed-files/action.yml
@@ -11,7 +11,7 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@v7
       id: result
       with:
         script: |

--- a/actions/json-args/action.yml
+++ b/actions/json-args/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@v7
       with:
         script: |
           const listRaw = `${{ inputs.list }}`;

--- a/actions/shared-node-cache/action.yml
+++ b/actions/shared-node-cache/action.yml
@@ -9,12 +9,12 @@ runs:
   using: "composite"
   steps:
     - name: Use Node.js ${{ inputs.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
 
     - name: Cache node_modules and cypress if it exists
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-node-modules
       with:
         path: |

--- a/utils/build.test.mjs
+++ b/utils/build.test.mjs
@@ -10,7 +10,7 @@ runs:
   steps:
     - name: Limited run
       uses: ./actions/json-args
-    - uses: actions/github-script@v6
+    - uses: actions/github-script@v7
       with:
         script: |
           require('./actions/full-or-limited/index.js')({github, core})
@@ -43,7 +43,7 @@ runs:
               steps:
                 - name: Limited run
                   uses: Our/monorepo@json-args-v1.2.3
-                - uses: actions/github-script@v6
+                - uses: actions/github-script@v7
                   with:
                     script: |
                       require('\${{ github.action_path }}/index.js')({github, core})


### PR DESCRIPTION
## Summary:

This PR bumps the following actions to their latest versions (which all involve moving to the Nove v20 runtime). The changes in this PR affect both the infrastructure of this repo (ie. the `.github` folder) as well as actions produced from this repo.

  * [actions/cache@v4](https://github.com/actions/cache/releases/tag/v4.0.0)
  * [actions/setup-node@v4](https://github.com/actions/setup-node/releases/tag/v4.0.0)
  * [actions/checkout@v4](https://github.com/actions/checkout/releases/tag/v4.0.0)
  * [actions/github-script@v7](https://github.com/actions/github-script?tab=readme-ov-file#v7)

This is to address the following warnings seen in the Khan/perseus repo:

<img width="600" alt="image" src="https://github.com/Khan/actions/assets/77138/b52e6c88-0249-4b65-8d2a-d1ae12ae99c4">

Issue: [FEI-5484](https://khanacademy.atlassian.net/browse/FEI-5484)

## Test plan:

Land this PR and then update the Perseus repo to use the new versions of the actions that are affected by this PR.

[FEI-5484]: https://khanacademy.atlassian.net/browse/FEI-5484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ