### PR TITLE
Update gerald action to Node 20

### DIFF
--- a/.changeset/long-ears-act.md
+++ b/.changeset/long-ears-act.md
@@ -1,0 +1,5 @@
+---
+"gerald-pr": major
+---
+
+Update to use Node 20

--- a/actions/gerald-pr/action.yml
+++ b/actions/gerald-pr/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
       - name: Get All Changed Files
-        uses: Khan/actions@get-changed-files-v1
+        uses: ./actions/get-changed-files
         id: changed
         if: ${{ github.event.pull_request.draft == false }}
       - name: Check out base branch
@@ -25,7 +25,7 @@ runs:
           ref: '${{ github.head_ref }}'
         if: ${{ github.event.pull_request.draft == false }}
       - name: Run Gerald
-        uses: Khan/gerald@v3.4
+        uses: Khan/gerald@v4.0
         env:
           GITHUB_TOKEN: '${{ inputs.token }}'
           ADMIN_PERMISSION_TOKEN: '${{ inputs.admin-token }}'


### PR DESCRIPTION
## Summary:
This updates the `gerald-pr` action to use the latest Khan/gerald release, supporting Node 20, and the repo version of `get-changed-files` so that it will be up-to-date on each release.

Issue: FEI-5545

## Test plan:
`yarn test`
Update consumers of this action to use the new version and see that they no longer warn of Node 16 deprecation.