### PR TITLE
[🔥AUDIT🔥] Make sure we have get-changed-files in the gerald-pr deps

### DIFF
--- a/.changeset/slow-colts-sell.md
+++ b/.changeset/slow-colts-sell.md
@@ -1,0 +1,5 @@
+---
+"gerald-pr": patch
+---
+
+Fix the gerald-pr deps

--- a/actions/gerald-pr/package.json
+++ b/actions/gerald-pr/package.json
@@ -1,4 +1,7 @@
 {
 	"name": "gerald-pr",
-	"version": "3.0.0"
+	"version": "3.0.0",
+    "dependencies": {
+        "get-changed-files": "*"
+    }
 }


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
I missed this step when I updated gerald-pr action to reference the repo version of get-changed-files. This PR adds that dependency so our build tooling will do the proper thing when releasing.

Issue: FEI-5545

## Test plan:
Put this up and look at the generated action.yml for the tagged gerald-pr release to make sure it has replaced the local reference with a versioned reference.