### PR TITLE
Have shared-node-cache install yarn

### DIFF
--- a/.changeset/serious-suns-camp.md
+++ b/.changeset/serious-suns-camp.md
@@ -1,0 +1,5 @@
+---
+"shared-node-cache": minor
+---
+
+Installing yarn as a step so that later steps don't fail

--- a/actions/shared-node-cache/action.yml
+++ b/actions/shared-node-cache/action.yml
@@ -13,6 +13,10 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
 
+    - run: npm install -g yarn
+      shell: bash
+      name: Install Yarn
+
     - name: Cache node_modules and cypress if it exists
       uses: actions/cache@v4
       id: cache-node-modules


### PR DESCRIPTION
## Summary:
Some of the new checks on OLC were failing, and seemed to be failing because the check `Khan/actions@shared-node-cache-v0` was failing because yarn couldn't be found.


![Screenshot_2024-05-28_at_3.53.24_PM.png](https://storage.googleapis.com/git-pr-images/b535f1e7154fdf2e71435158eab68ec0_Screenshot_2024-05-28_at_3.53.24_PM.png) 

Now this check installs yarn.

Issue: XXX-XXXX

## Test plan:
I tested this on the branch `yarn-bug` and changed OLC to point to that branch:
`Khan/actions@408dc12489a0a87a7a1f5368afa0a251c147dc43` and now it's working. (PR [here](https://github.com/Khan/our-lovely-cli/pull/656))