### PR TITLE
Bumping actions/gerald-pr to point to newer version of Khan/gerald

### DIFF
--- a/.changeset/cuddly-poets-listen.md
+++ b/.changeset/cuddly-poets-listen.md
@@ -1,0 +1,5 @@
+---
+"gerald-pr": minor
+---
+
+Bumping actions/gerald-pr to point to newer version of Khan/gerald

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Here's what I did:
 1. Find the last tagged-and-published version of that action (e.g., `gerald-pr-v0.0.1`).
 2. Run `git checkout gerald-pr-v0.0.1` to create a detached HEAD.
 3. Run `git checkout -b <branch-name>` to create a new branch with just those files.
-4. Apply the changes to my development branch to this branch: ``
-5. Push the branch to the GitHub
-6. Point my other repo to this branch with `uses: @Khan/actions@<branch-name>`
+4. Apply the changes to my development branch to this branch. Sometimes `git cherry-pick` can figure out the file-structure differences across branches. You can also manually create and apply patches. Or just manually bring in the changes, if they're small enough and you're careful enough.
+5. Push the branch to the GitHub.
+6. Point my other repo to my test branch with `uses: @Khan/actions@<branch-name>`.
+

--- a/README.md
+++ b/README.md
@@ -12,4 +12,17 @@ Actions that depend on other actions within this repo (with e.g. `uses: filter-f
 
 ## How does changeset play in?
 
-Changeset helps us track what needs to be published, and automatically produces a changelog so we know what changed in a given release.
+Changeset helps us track what needs to be published, and automatically produces a changelog, so we know what changed in a given release.
+
+## How do I test just one action, before publishing?
+(Note [Lilli]: I don't know if there's a better way; this is just what I did.)
+
+Let's say I want to test a change to the `gerald-pr` action, pointed to from a different repo. I'm still working on it, so I don't want to publish it yet (as described above). I still need to get the action isolated in its own folder, outside the sub-folders of the monorepo.
+
+Here's what I did:
+1. Find the last tagged-and-published version of that action (e.g., `gerald-pr-v0.0.1`).
+2. Run `git checkout gerald-pr-v0.0.1` to create a detached HEAD.
+3. Run `git checkout -b <branch-name>` to create a new branch with just those files.
+4. Apply the changes to my development branch to this branch: ``
+5. Push the branch to the GitHub
+6. Point my other repo to this branch with `uses: @Khan/actions@<branch-name>`

--- a/actions/gerald-pr/action.yml
+++ b/actions/gerald-pr/action.yml
@@ -25,7 +25,7 @@ runs:
           ref: '${{ github.head_ref }}'
         if: ${{ github.event.pull_request.draft == false }}
       - name: Run Gerald
-        uses: Khan/gerald@v4
+        uses: Khan/gerald@v4.1
         env:
           GITHUB_TOKEN: '${{ inputs.token }}'
           ADMIN_PERMISSION_TOKEN: '${{ inputs.admin-token }}'

--- a/actions/gerald-pr/action.yml
+++ b/actions/gerald-pr/action.yml
@@ -25,7 +25,7 @@ runs:
           ref: '${{ github.head_ref }}'
         if: ${{ github.event.pull_request.draft == false }}
       - name: Run Gerald
-        uses: Khan/gerald@v4.1
+        uses: Khan/gerald@v4
         env:
           GITHUB_TOKEN: '${{ inputs.token }}'
           ADMIN_PERMISSION_TOKEN: '${{ inputs.admin-token }}'

--- a/actions/gerald-pr/action.yml
+++ b/actions/gerald-pr/action.yml
@@ -25,7 +25,7 @@ runs:
           ref: '${{ github.head_ref }}'
         if: ${{ github.event.pull_request.draft == false }}
       - name: Run Gerald
-        uses: Khan/gerald@v4.0
+        uses: Khan/gerald@v4.1
         env:
           GITHUB_TOKEN: '${{ inputs.token }}'
           ADMIN_PERMISSION_TOKEN: '${{ inputs.admin-token }}'


### PR DESCRIPTION
## Summary:
See [this PR](https://github.com/Khan/gerald/pull/87) with a bug-fix regarding GitHub teams not getting added when author is a member of that team, and the author adds comments. Point this to that, once it's landed and tagged.

I also updated the README with instructions (mostly for myself, because I forgot what I did last time) on how to test PRs in this repo _before_ landing (and publishing).

Issue: XXX-XXXX

## Test plan: