### PR TITLE
Update gerald-pr to point to the new v5 version.

### DIFF
--- a/actions/gerald-pr/CHANGELOG.md
+++ b/actions/gerald-pr/CHANGELOG.md
@@ -1,5 +1,23 @@
 # gerald-pr
 
+## 5.0.0
+
+### Major Changes
+
+-   4f836bc: Add support for labels to NOTIFIED and REVIEWERS rules
+
+## 4.1.0
+
+-   Unknown
+
+## 4.0.0
+
+-   Unknown
+
+### Minor Changes
+
+-   52a237a: Bumping actions/gerald-pr to point to newer version of Khan/gerald
+
 ## 3.1.0
 
 ### Minor Changes

--- a/actions/gerald-pr/action.yml
+++ b/actions/gerald-pr/action.yml
@@ -25,7 +25,7 @@ runs:
           ref: '${{ github.head_ref }}'
         if: ${{ github.event.pull_request.draft == false }}
       - name: Run Gerald
-        uses: Khan/gerald@v4.1
+        uses: Khan/gerald@v5
         env:
           GITHUB_TOKEN: '${{ inputs.token }}'
           ADMIN_PERMISSION_TOKEN: '${{ inputs.admin-token }}'

--- a/actions/gerald-pr/package.json
+++ b/actions/gerald-pr/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gerald-pr",
-    "version": "3.1.0",
+    "version": "5.0.0",
     "dependencies": {
         "get-changed-files": "*"
     }


### PR DESCRIPTION
## Summary:
Boy this is a complex workflow!  Here's what I needed to do:
1. Create a `v5` tag in Khan/gerald, pointing to the new code
2. Change action.yml here to point to Khan/gerald@v5
3. Land this
4. Push a tag call gerald-pr-v5 that points to the new HEAD here
5. Update webapp's .github/actions/gerald-pr.yml to point to gerald-pr-v5

Issue: https://khanacademy.atlassian.net/browse/FEI-5970

## Test plan:
Fingers crossed