### PR TITLE
Allow running shared-node-cache without ssh-private-key

### DIFF
--- a/.changeset/nervous-actors-tell.md
+++ b/.changeset/nervous-actors-tell.md
@@ -1,0 +1,5 @@
+---
+"shared-node-cache": minor
+---
+
+Make `ssh-private-key` optional on the shared-node-cache action

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./actions/shared-node-cache
-        with:
-          ssh-private-key: ${{ secrets.KHAN_ACTIONS_BOT_SSH_PRIVATE_KEY }}
       - run: pnpm run lint
 
       # Test filter-files

--- a/actions/shared-node-cache/action.yml
+++ b/actions/shared-node-cache/action.yml
@@ -7,7 +7,8 @@ inputs:
     default: '20.x'
   ssh-private-key:
     description: 'A private SSH key so that we can obtain private dependencies like our event schema package'
-    required: true
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -24,6 +25,7 @@ runs:
     # Set up SSH key so that the install step can install packages from private
     # git repos.
     - uses: webfactory/ssh-agent@v0.9.0
+      if: ${{ inputs.ssh-private-key }} != ""
       with:
         ssh-private-key: ${{ inputs.ssh-private-key }}
 

--- a/actions/shared-node-cache/action.yml
+++ b/actions/shared-node-cache/action.yml
@@ -25,7 +25,7 @@ runs:
     # Set up SSH key so that the install step can install packages from private
     # git repos.
     - uses: webfactory/ssh-agent@v0.9.0
-      if: ${{ inputs.ssh-private-key != "" }}
+      if: ${{ inputs.ssh-private-key != '' }}
       with:
         ssh-private-key: ${{ inputs.ssh-private-key }}
 

--- a/actions/shared-node-cache/action.yml
+++ b/actions/shared-node-cache/action.yml
@@ -25,7 +25,7 @@ runs:
     # Set up SSH key so that the install step can install packages from private
     # git repos.
     - uses: webfactory/ssh-agent@v0.9.0
-      if: ${{ inputs.ssh-private-key }} != ""
+      if: ${{ inputs.ssh-private-key != "" }}
       with:
         ssh-private-key: ${{ inputs.ssh-private-key }}
 


### PR DESCRIPTION
## Summary:

In the last PR I added a `ssh-private-key` input to the `shared-node-cache` action. However, this isn't needed/used in all cases and so making it required breaks some existing usages. I've made it optional now and only run the `webfactory/ssh-agent` action if a key has been provided. 

Issue: --none--

## Test plan:

Watch the actions. The `shared-node-cache` action is run in this repo as part of PR checks. That run is now set up to _not_ provide an `ssh-private-key`. I'll verify that it works _with_ an `ssh-private-key` after landing and integrating in another repo.