### PR TITLE
Filter out comment lines in inputs

### DIFF
--- a/.changeset/dry-pears-sing.md
+++ b/.changeset/dry-pears-sing.md
@@ -1,0 +1,5 @@
+---
+"filter-files": major
+---
+
+Filtering out #comments in multiline input lists

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -45,12 +45,12 @@ jobs:
       - uses: ./actions/filter-files
         id: fftest6
         with:
-          changed-files: '["one", "two/three", "two/three/four"]'
+          changed-files: '["one/two", "one/three"]'
           globs: |
             # Comment here
-            !two
+            !*/three
             # With comments
-            o*
+            one/*
 
       - uses: actions/github-script@v7
         name: Test the 'filter-files' action
@@ -77,7 +77,7 @@ jobs:
               core.setFailed('fftest5: ' + fftest5)
             }
             const fftest6 = `${{ steps.fftest6.outputs.filtered }}`;
-            if (fftest6 !== `["one"]`) {
+            if (fftest6 !== `["one/two"]`) {
               core.setFailed('fftest6: ' + fftest6)
             }
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           changed-files: '["one", "two/three", "two/three/four"]'
           globs:
-            - !two
+            - '!two'
             - o*
 
       - uses: actions/github-script@v7

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -46,9 +46,11 @@ jobs:
         id: fftest6
         with:
           changed-files: '["one", "two/three", "two/three/four"]'
-          globs:
-            - '!two'
-            - o*
+          globs: |
+            # Comment here
+            !two
+            # With comments
+            o*
 
       - uses: actions/github-script@v7
         name: Test the 'filter-files' action

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -45,12 +45,11 @@ jobs:
       - uses: ./actions/filter-files
         id: fftest6
         with:
-          changed-files: '["one/two", "one/three"]'
+          changed-files: '["one/two", "two/three"]'
           globs: |
             # Comment here
-            !*/three
-            # With comments
             one/*
+            # With comments
 
       - uses: actions/github-script@v7
         name: Test the 'filter-files' action

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -42,6 +42,13 @@ jobs:
           changed-files: '["one", "two/three", "two/three/four"]'
           files: 'two/three'
           invert: true
+      - uses: ./actions/filter-files
+        id: fftest6
+        with:
+          changed-files: '["one", "two/three", "two/three/four"]'
+          globs:
+            - !two
+            - o*
 
       - uses: actions/github-script@v7
         name: Test the 'filter-files' action
@@ -66,6 +73,10 @@ jobs:
             const fftest5 = `${{ steps.fftest5.outputs.filtered }}`;
             if (fftest5 !== `["one","two/three/four"]`) {
               core.setFailed('fftest5: ' + fftest5)
+            }
+            const fftest6 = `${{ steps.fftest6.outputs.filtered }}`;
+            if (fftest6 !== `["one"]`) {
+              core.setFailed('fftest6: ' + fftest6)
             }
 
       - uses: ./actions/get-changed-files

--- a/actions/filter-files/action.yml
+++ b/actions/filter-files/action.yml
@@ -39,6 +39,7 @@ runs:
           const extensionsRaw = `${{ inputs.extensions }}`;
           const exactFilesRaw = `${{ inputs.files }}`;
           const globsRaw = `${{ inputs.globs }}`;
+          console.log('the glubs', globsRaw)
           const matchAllGlobs = ${{ inputs.matchAllGlobs == 'true' }};
           const inputFilesRaw = `${{ inputs.changed-files }}`;
           if (inputFilesRaw.trim() === '') {

--- a/actions/filter-files/filter-files.test.mjs
+++ b/actions/filter-files/filter-files.test.mjs
@@ -3,6 +3,24 @@ import filterFiles from ".";
 describe("filterFiles", () => {
     const core = console;
 
+    it("should honor NOT globs", () => {
+        const inputFiles = [
+            "other/thing.ts",
+            "packages/this-one.ts",
+            "packages/some.json",
+        ];
+
+        const result = filterFiles({
+            globsRaw: `packages/*\n!packages/*.json`,
+            inputFiles,
+            matchAllGlobs: true,
+            core,
+        });
+
+        // Assert
+        expect(result).toEqual(["packages/this-one.ts"]);
+    });
+
     it("should ignore comment lines", () => {
         const inputFiles = ["other/thing.ts", "packages/this-one.ts"];
 

--- a/actions/filter-files/filter-files.test.mjs
+++ b/actions/filter-files/filter-files.test.mjs
@@ -3,6 +3,20 @@ import filterFiles from ".";
 describe("filterFiles", () => {
     const core = console;
 
+    it("should ignore comment lines", () => {
+        const inputFiles = ["other/thing.ts", "packages/this-one.ts"];
+
+        const result = filterFiles({
+            globsRaw: `# this is a comment\nother/*`,
+            inputFiles,
+            matchAllGlobs: true,
+            core,
+        });
+
+        // Assert
+        expect(result).toEqual(["other/thing.ts"]);
+    });
+
     it("should return a new array files that are not filtered", () => {
         // Arrange
         const invert = true;

--- a/actions/filter-files/index.js
+++ b/actions/filter-files/index.js
@@ -11,7 +11,13 @@ const parseList = (raw) => {
     }
     if (raw.includes("\n")) {
         // if split on newlines, no need to parse for internal commas
-        return raw.split("\n").map((item) => item.trim());
+        return (
+            raw
+                .split("\n")
+                .map((item) => item.trim())
+                // Filter out comment lines
+                .filter((line) => !line.startsWith("#"))
+        );
     }
 
     let bracketCount = 0;

--- a/actions/filter-files/index.js
+++ b/actions/filter-files/index.js
@@ -99,7 +99,7 @@ module.exports = ({
     }
     if (globsRaw) {
         const globsList = parseList(globsRaw);
-        console.log("parsed globs list", globsList);
+        core.info("parsed globs list", globsList);
         // picomatch does does inclusive disjunctions (ORs) by default,
         //   so we need to do some extra work to get conjunctive (AND) matches.
         // test this behavior here: https://codesandbox.io/s/picomatch-forked-qgqy2g

--- a/actions/filter-files/index.js
+++ b/actions/filter-files/index.js
@@ -99,12 +99,6 @@ module.exports = ({
     }
     if (globsRaw) {
         const globsList = parseList(globsRaw);
-        core.info(
-            "parsed globs list: " +
-                JSON.stringify(globsList) +
-                "\nRaw:\n" +
-                globsRaw,
-        );
         // picomatch does does inclusive disjunctions (ORs) by default,
         //   so we need to do some extra work to get conjunctive (AND) matches.
         // test this behavior here: https://codesandbox.io/s/picomatch-forked-qgqy2g

--- a/actions/filter-files/index.js
+++ b/actions/filter-files/index.js
@@ -99,7 +99,12 @@ module.exports = ({
     }
     if (globsRaw) {
         const globsList = parseList(globsRaw);
-        core.info("parsed globs list", globsList);
+        core.info(
+            "parsed globs list: " +
+                JSON.stringify(globsList) +
+                "\nRaw:\n" +
+                globsRaw,
+        );
         // picomatch does does inclusive disjunctions (ORs) by default,
         //   so we need to do some extra work to get conjunctive (AND) matches.
         // test this behavior here: https://codesandbox.io/s/picomatch-forked-qgqy2g

--- a/actions/filter-files/index.js
+++ b/actions/filter-files/index.js
@@ -16,7 +16,7 @@ const parseList = (raw) => {
                 .split("\n")
                 .map((item) => item.trim())
                 // Filter out comment lines
-                .filter((line) => !line.startsWith("#"))
+                .filter((line) => line.length && !line.startsWith("#"))
         );
     }
 

--- a/actions/filter-files/index.js
+++ b/actions/filter-files/index.js
@@ -99,6 +99,7 @@ module.exports = ({
     }
     if (globsRaw) {
         const globsList = parseList(globsRaw);
+        console.log("parsed globs list", globsList);
         // picomatch does does inclusive disjunctions (ORs) by default,
         //   so we need to do some extra work to get conjunctive (AND) matches.
         // test this behavior here: https://codesandbox.io/s/picomatch-forked-qgqy2g


### PR DESCRIPTION
## Summary:
I'm going to be using a rather lengthy set of glob filters for the deploy workflow in the frontend repo, and I want the ability to separate them into sections with.

Issue: FEI-XXXX

## Test plan:
see tests