### PR TITLE
Change behavior of "negative globs" to match .gitignore

### DIFF
--- a/.changeset/weak-beans-sniff.md
+++ b/.changeset/weak-beans-sniff.md
@@ -1,0 +1,5 @@
+---
+"filter-files": major
+---
+
+Change behavior of "negative globs" to match .gitignore

--- a/actions/filter-files/filter-files.test.mjs
+++ b/actions/filter-files/filter-files.test.mjs
@@ -13,7 +13,6 @@ describe("filterFiles", () => {
         const result = filterFiles({
             globsRaw: `packages/*\n!packages/*.json`,
             inputFiles,
-            matchAllGlobs: true,
             core,
         });
 
@@ -50,8 +49,10 @@ describe("filterFiles", () => {
             "packages/this-one.ts",
         ];
         const expected = [
+            "other/thing.ts",
             "packages/core/src/index.ts",
             "packages/core/src/index.jsx",
+            "packages/core/src/styles.css",
         ];
         // splitting on newline
         const extensionsRaw = `test.ts
@@ -61,8 +62,7 @@ describe("filterFiles", () => {
         // splitting on comma and ignoring whitespace
         const exactFilesRaw = ".github/, .changeset/";
         // not splitting inside brackets
-        const globsRaw =
-            "!(packages/**/*.{ts,tsx,js,jsx}), packages/this-one.ts";
+        const globsRaw = "packages/this-one.ts, packages/**/*.test.ts";
 
         // Act
         const result = filterFiles({
@@ -165,7 +165,7 @@ describe("filterFiles", () => {
         ];
         const extensionsRaw = `ts,js,jsx,tsx`;
         const exactFilesRaw = "packages/";
-        const globsRaw = "!(packages/**/*.test.*), packages/this-one.ts";
+        const globsRaw = "packages/this-one.ts";
 
         // Act
         const result = filterFiles({
@@ -197,12 +197,13 @@ describe("filterFiles", () => {
             "packages/core/src/index.ts",
             "packages/core/src/index.test.ts",
             "packages/core/src/index.jsx",
+            "packages/core/src/index.test.jsx",
             "packages/this-one.ts",
         ];
         const extensionsRaw = `ts,js,jsx,tsx`;
         const exactFilesRaw = "packages/";
         // globs is inclusive disjunction (OR) by default
-        const globsRaw = "!(packages/**/*.test.*), packages/**/*.test.ts";
+        const globsRaw = "**/src/*, **/*-one.ts";
 
         // Act
         const result = filterFiles({

--- a/actions/filter-files/index.js
+++ b/actions/filter-files/index.js
@@ -111,13 +111,12 @@ module.exports = ({
             if (nots.length) {
                 const yeses = globsList.filter((glob) => !glob.startsWith("!"));
                 filters.push((path) => {
-                    const yesesMatch = yeses.some((glob) =>
-                        picomatch(glob)(path),
-                    );
+                    const yesesMatch =
+                        !yesses.length ||
+                        yeses.some((glob) => picomatch(glob)(path));
                     const noesMatch = nots.every((glob) =>
                         picomatch(glob)(path),
                     );
-                    console.log("check", path, yesesMatch, noesMatch);
                     return yesesMatch && noesMatch;
                 });
             } else {
@@ -131,7 +130,6 @@ module.exports = ({
         const matched = conjunctive
             ? bools.every(Boolean)
             : bools.some(Boolean);
-        console.log("bools", bools, name, matched);
         return matched === !invert;
     });
     core.info(`Filtered Files: ${JSON.stringify(result)}`);

--- a/actions/filter-files/index.js
+++ b/actions/filter-files/index.js
@@ -112,7 +112,7 @@ module.exports = ({
                 const yeses = globsList.filter((glob) => !glob.startsWith("!"));
                 filters.push((path) => {
                     const yesesMatch =
-                        !yesses.length ||
+                        !yeses.length ||
                         yeses.some((glob) => picomatch(glob)(path));
                     const noesMatch = nots.every((glob) =>
                         picomatch(glob)(path),


### PR DESCRIPTION
## Summary:
The current behavior of negative globs only makes sense if `matchAllGlobs` is true. If it's false, then weird things happen. For example:
```
input files:
- one/two.js
- one/two/three.test.ts
- one/two.json
globs:
one/**
!**/*.test.ts
!**/*.json
```
The behavior is "a file 'matches' if any of the globs match". As you can see in this case, given two negative non-intersecting globs, all files will always match, because at least one of them will match for every file.

I'm changing it so that if `matchAllGlobs` is false, then the behavior is: "all negative globs have to match, and at least one positive glob needs to match".
With this, the result of the above example would be `one/two.js`, which I think is intuitive.

Issue: none

## Test plan:
See the test I added.