### PR TITLE
Add a `matched_any` output to filter-files

### DIFF
--- a/.changeset/five-camels-tap.md
+++ b/.changeset/five-camels-tap.md
@@ -1,0 +1,5 @@
+---
+"filter-files": minor
+---
+
+Add a matched_any output to filter-files

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -79,6 +79,10 @@ jobs:
             if (fftest6 !== `["one/two"]`) {
               core.setFailed('fftest6: ' + fftest6)
             }
+            const sixMatched = ${{ steps.fftest6.outputs.matched_any }};
+            if (!sixMatched) {
+              core.setFailed('fftest6 matched_any: ' + fftest6)
+            }
 
       - uses: ./actions/get-changed-files
         id: changed-limited

--- a/actions/filter-files/action.yml
+++ b/actions/filter-files/action.yml
@@ -29,6 +29,9 @@ outputs:
   filtered:
     description: 'The jsonified list of files that match'
     value: ${{ steps.result.outputs.result }}
+  matched_any:
+    description: 'True if any files were matched'
+    value: ${{ steps.result.outputs.result != '[]' }}
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
## Summary:
It's a very common pattern to do `steps.changed-files.outputs.filtered != '[]'`, and this will make it cleaner.

Issue: none

## Test plan:
see node-ci.yml