### PR TITLE
Add `merge_group` event support to the get-changed-files action

### DIFF
--- a/.changeset/sour-streets-mix.md
+++ b/.changeset/sour-streets-mix.md
@@ -1,0 +1,5 @@
+---
+"get-changed-files": minor
+---
+
+Add `merge_group` event support to the get-changed-files action

--- a/actions/get-changed-files/index.js
+++ b/actions/get-changed-files/index.js
@@ -10,6 +10,11 @@ const getBaseAndHead = (context, core) => {
             ];
         case "push":
             return [context.payload.before, context.payload.after];
+        case "merge_group":
+            return [
+                context.payload.merge_group.base_sha,
+                context.payload.merge_group.head_sha,
+            ];
         default:
             core.setFailed(
                 `This action only supports pull requests and pushes, ${context.eventName} events are not supported. ` +


### PR DESCRIPTION
## Summary:
yay merge groups

Issue: none

## Test plan:
in order to test it I'll need to run it on a repo that has a merge queue, which I don't want to set up for this repo at the moment 😬