### PR TITLE
fix-workflows: exempt macos- runners from all fixups

### DIFF
--- a/.changeset/major-cooks-matter.md
+++ b/.changeset/major-cooks-matter.md
@@ -1,0 +1,5 @@
+---
+"fix-workflows": patch
+---
+
+Exclude fixing up macos runners.

--- a/actions/fix-workflows/index.test.ts
+++ b/actions/fix-workflows/index.test.ts
@@ -3,10 +3,13 @@ import {isMap, isSeq, parseDocument} from "yaml";
 
 import {
     DEFAULT_SETUP_ACTION,
+    checkJob,
     checkRunsOn,
     checkSteps,
     fixRunsOn,
     fixSteps,
+    isExemptRunner,
+    processJob,
 } from "./index.ts";
 
 // ---------------------------------------------------------------------------
@@ -451,6 +454,42 @@ function parseWorkflowJob(yaml: string) {
     return job;
 }
 
+/** Parse a YAML string and return the document and first job's map node. */
+function parseWorkflowJobWithDoc(yaml: string) {
+    const doc = parseDocument(yaml);
+    const jobs = doc.get("jobs") as any;
+    const job = jobs.items[0].value;
+    if (!isMap(job)) {
+        throw new Error("Expected a job map");
+    }
+    return {doc, job};
+}
+
+// ---------------------------------------------------------------------------
+// isExemptRunner
+// ---------------------------------------------------------------------------
+
+describe("isExemptRunner", () => {
+    it.each([
+        ["returns true for macos-latest", "macos-latest", true],
+        ["returns true for macos-15", "macos-15", true],
+        ["returns false for ubuntu-latest", "ubuntu-latest", false],
+        [
+            "returns false for the conditional expression",
+            "${{ vars.USE_GITHUB_RUNNERS == 'true' && 'ubuntu-latest' || 'ephemeral-runner' }}",
+            false,
+        ],
+    ])("%s", (_name, runsOn, expected) => {
+        const job = parseWorkflowJob(`
+jobs:
+  build:
+    runs-on: "${runsOn}"
+    steps: []
+`);
+        expect(isExemptRunner(job)).toBe(expected);
+    });
+});
+
 // ---------------------------------------------------------------------------
 // checkRunsOn
 // ---------------------------------------------------------------------------
@@ -496,6 +535,26 @@ jobs:
     steps: []
 `,
             true,
+        ],
+        [
+            "returns false for a macos- runner",
+            `
+jobs:
+  build:
+    runs-on: macos-latest
+    steps: []
+`,
+            false,
+        ],
+        [
+            "returns false for a versioned macos- runner",
+            `
+jobs:
+  build:
+    runs-on: macos-15
+    steps: []
+`,
+            false,
         ],
     ])("%s", (_name, yaml, expected) => {
         // Arrange
@@ -552,6 +611,23 @@ jobs:
         );
     });
 
+    it("returns false and leaves runs-on unchanged for a macos- runner", () => {
+        // Arrange
+        const job = parseWorkflowJob(`
+jobs:
+  build:
+    runs-on: macos-latest
+    steps: []
+`);
+
+        // Act
+        const result = fixRunsOn(job);
+
+        // Assert
+        expect(result).toBe(false);
+        expect(job.get("runs-on")).toBe("macos-latest");
+    });
+
     it("replaces ubuntu-latest-l with the large-runner conditional expression", () => {
         // Arrange
         const job = parseWorkflowJob(`
@@ -569,5 +645,179 @@ jobs:
         expect(job.get("runs-on")).toBe(
             "${{ vars.USE_GITHUB_RUNNERS == 'true' && 'ubuntu-latest-l' || 'ephemeral-runner' }}",
         );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// processJob
+// ---------------------------------------------------------------------------
+
+describe("processJob", () => {
+    it("returns false and makes no changes for a macos- runner even when checkout lacks setup", () => {
+        // Arrange
+        const {doc, job} = parseWorkflowJobWithDoc(`
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build
+        run: pnpm build
+`);
+        const stepsBefore = JSON.stringify(job.toJSON());
+
+        // Act
+        const result = processJob(doc, job);
+
+        // Assert
+        expect(result).toBe(false);
+        expect(JSON.stringify(job.toJSON())).toBe(stepsBefore);
+    });
+
+    it("inserts a secure-network step for a non-exempt runner", () => {
+        // Arrange
+        const {doc, job} = parseWorkflowJobWithDoc(`
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build
+        run: pnpm build
+`);
+
+        // Act
+        const result = processJob(doc, job);
+
+        // Assert
+        expect(result).toBe(true);
+        const steps = job.toJSON().steps;
+        expect(steps[1]).toMatchObject({
+            name: "Secure Network",
+            uses: DEFAULT_SETUP_ACTION,
+            "timeout-minutes": 5,
+        });
+    });
+
+    it("fixes runs-on when shouldFixRunsOn is true and runner is non-exempt", () => {
+        // Arrange
+        const {doc, job} = parseWorkflowJobWithDoc(`
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps: []
+`);
+
+        // Act
+        const result = processJob(doc, job, {shouldFixRunsOn: true});
+
+        // Assert
+        expect(result).toBe(true);
+        expect(job.get("runs-on")).toBe(
+            "${{ vars.USE_GITHUB_RUNNERS == 'true' && 'ubuntu-latest' || 'ephemeral-runner' }}",
+        );
+    });
+
+    it("does not fix runs-on for a macos- runner even when shouldFixRunsOn is true", () => {
+        // Arrange
+        const {doc, job} = parseWorkflowJobWithDoc(`
+jobs:
+  build:
+    runs-on: macos-latest
+    steps: []
+`);
+
+        // Act
+        const result = processJob(doc, job, {shouldFixRunsOn: true});
+
+        // Assert
+        expect(result).toBe(false);
+        expect(job.get("runs-on")).toBe("macos-latest");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// checkJob
+// ---------------------------------------------------------------------------
+
+describe("checkJob", () => {
+    it("returns false for a macos- runner even when checkout lacks setup", () => {
+        // Arrange
+        const job = parseWorkflowJob(`
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build
+        run: pnpm build
+`);
+
+        // Act & Assert
+        expect(checkJob(job)).toBe(false);
+    });
+
+    it("returns false for a macos- runner even when shouldFixRunsOn is true", () => {
+        // Arrange
+        const job = parseWorkflowJob(`
+jobs:
+  build:
+    runs-on: macos-latest
+    steps: []
+`);
+
+        // Act & Assert
+        expect(checkJob(job, {shouldFixRunsOn: true})).toBe(false);
+    });
+
+    it("returns true for a non-exempt runner missing the secure-network step", () => {
+        // Arrange
+        const job = parseWorkflowJob(`
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build
+        run: pnpm build
+`);
+
+        // Act & Assert
+        expect(checkJob(job)).toBe(true);
+    });
+
+    it("returns true for a non-exempt runner with a plain runs-on when shouldFixRunsOn is true", () => {
+        // Arrange
+        const job = parseWorkflowJob(`
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps: []
+`);
+
+        // Act & Assert
+        expect(checkJob(job, {shouldFixRunsOn: true})).toBe(true);
+    });
+
+    it("returns false when there are no violations", () => {
+        // Arrange
+        const job = parseWorkflowJob(`
+jobs:
+  build:
+    runs-on: "\${{ vars.USE_GITHUB_RUNNERS == 'true' && 'ubuntu-latest' || 'ephemeral-runner' }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Secure Network
+        uses: ${DEFAULT_SETUP_ACTION}
+        timeout-minutes: 5
+`);
+
+        // Act & Assert
+        expect(checkJob(job, {shouldFixRunsOn: true})).toBe(false);
     });
 });

--- a/actions/fix-workflows/index.ts
+++ b/actions/fix-workflows/index.ts
@@ -209,7 +209,10 @@ type JobOptions = {
 export function processJob(
     doc: Document,
     job: YAMLMap,
-    {shouldFixRunsOn = false, setupAction = DEFAULT_SETUP_ACTION}: JobOptions = {},
+    {
+        shouldFixRunsOn = false,
+        setupAction = DEFAULT_SETUP_ACTION,
+    }: JobOptions = {},
 ): boolean {
     if (isExemptRunner(job)) {
         return false;
@@ -231,7 +234,10 @@ export function processJob(
  */
 export function checkJob(
     job: YAMLMap,
-    {shouldFixRunsOn = false, setupAction = DEFAULT_SETUP_ACTION}: JobOptions = {},
+    {
+        shouldFixRunsOn = false,
+        setupAction = DEFAULT_SETUP_ACTION,
+    }: JobOptions = {},
 ): boolean {
     if (isExemptRunner(job)) {
         return false;
@@ -262,7 +268,8 @@ export function processFile(
             if (!isMap(item.value)) {
                 continue;
             }
-            changed = processJob(doc, item.value as YAMLMap, options) || changed;
+            changed =
+                processJob(doc, item.value as YAMLMap, options) || changed;
         }
     }
 
@@ -312,7 +319,10 @@ export default async function fixWorkflows({
             for (const item of jobs.items) {
                 if (
                     isMap(item.value) &&
-                    checkJob(item.value as YAMLMap, {shouldFixRunsOn, setupAction})
+                    checkJob(item.value as YAMLMap, {
+                        shouldFixRunsOn,
+                        setupAction,
+                    })
                 ) {
                     broken = true;
                     break;

--- a/actions/fix-workflows/index.ts
+++ b/actions/fix-workflows/index.ts
@@ -160,12 +160,24 @@ export function checkSteps(
 }
 
 /**
+ * Return true if the job's runner is exempt from all fixups.
+ * macOS runners are GitHub-hosted and don't use our secure network setup.
+ */
+export function isExemptRunner(job: YAMLMap): boolean {
+    const runsOn = job.get("runs-on");
+    return typeof runsOn === "string" && runsOn.startsWith("macos-");
+}
+
+/**
  * Return true if the job's `runs-on` value is non-compliant (i.e., it is a
  * plain runner name rather than the required conditional expression).
  */
 export function checkRunsOn(job: YAMLMap): boolean {
     const runsOn = job.get("runs-on");
     if (typeof runsOn !== "string") {
+        return false;
+    }
+    if (isExemptRunner(job)) {
         return false;
     }
     return !VALID_RUNS_ON_RE.test(runsOn);
@@ -185,38 +197,72 @@ export function fixRunsOn(job: YAMLMap): boolean {
     return true;
 }
 
+type JobOptions = {
+    shouldFixRunsOn?: boolean;
+    setupAction?: string;
+};
+
+/**
+ * Apply all fixes to a single job map. Skips exempt runners entirely.
+ * Returns true if any changes were made.
+ */
+export function processJob(
+    doc: Document,
+    job: YAMLMap,
+    {shouldFixRunsOn = false, setupAction = DEFAULT_SETUP_ACTION}: JobOptions = {},
+): boolean {
+    if (isExemptRunner(job)) {
+        return false;
+    }
+    let changed = false;
+    if (shouldFixRunsOn) {
+        changed = fixRunsOn(job) || changed;
+    }
+    const steps = (job as any).get("steps");
+    if (isSeq(steps)) {
+        changed = fixSteps(doc, steps, setupAction) || changed;
+    }
+    return changed;
+}
+
+/**
+ * Return true if a single job map has any remaining violations.
+ * Always returns false for exempt runners.
+ */
+export function checkJob(
+    job: YAMLMap,
+    {shouldFixRunsOn = false, setupAction = DEFAULT_SETUP_ACTION}: JobOptions = {},
+): boolean {
+    if (isExemptRunner(job)) {
+        return false;
+    }
+    const steps = (job as any).get("steps");
+    return (
+        (shouldFixRunsOn && checkRunsOn(job)) ||
+        (isSeq(steps) && checkSteps(steps, setupAction))
+    );
+}
+
 /**
  * Parse the file, fix any violations, and write it back if changed.
  * Returns true if the file was modified.
  */
 export function processFile(
     filePath: string,
-    options: {
-        shouldFixRunsOn?: boolean;
-        setupAction?: string;
-    } = {},
+    options: JobOptions = {},
 ): boolean {
-    const {shouldFixRunsOn = false, setupAction = DEFAULT_SETUP_ACTION} =
-        options;
     const absPath = path.join(repoRoot, filePath);
     const content = fs.readFileSync(absPath, "utf8");
     const doc = parseDocument(content);
     let changed = false;
 
-    // Workflow files: jobs.<id>.runs-on and jobs.<id>.steps
     const jobs = doc.get("jobs");
     if (isMap(jobs)) {
         for (const item of jobs.items) {
             if (!isMap(item.value)) {
                 continue;
             }
-            if (shouldFixRunsOn) {
-                changed = fixRunsOn(item.value as YAMLMap) || changed;
-            }
-            const steps = (item.value as any).get("steps");
-            if (isSeq(steps)) {
-                changed = fixSteps(doc, steps, setupAction) || changed;
-            }
+            changed = processJob(doc, item.value as YAMLMap, options) || changed;
         }
     }
 
@@ -260,22 +306,16 @@ export default async function fixWorkflows({
         const content = fs.readFileSync(path.join(repoRoot, file), "utf8");
         const doc = parseDocument(content);
 
-        const hasStepsViolation = (steps: any) =>
-            isSeq(steps) && checkSteps(steps, setupAction);
-
         let broken = false;
         const jobs = doc.get("jobs");
         if (isMap(jobs)) {
             for (const item of jobs.items) {
-                if (isMap(item.value)) {
-                    if (
-                        (shouldFixRunsOn &&
-                            checkRunsOn(item.value as YAMLMap)) ||
-                        hasStepsViolation((item.value as any).get("steps"))
-                    ) {
-                        broken = true;
-                        break;
-                    }
+                if (
+                    isMap(item.value) &&
+                    checkJob(item.value as YAMLMap, {shouldFixRunsOn, setupAction})
+                ) {
+                    broken = true;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Jobs whose \`runs-on\` starts with \`macos-\` are now skipped entirely by the
fix-workflows action — no secure-network step insertion, no runs-on
rewrite, and no violation reported in the verification pass.

Introduces \`isExemptRunner\` as the single source of truth for the
exemption, and extracts \`processJob\` / \`checkJob\` so the per-job logic is
unit-testable without filesystem I/O (37 tests, all passing).

Reviewers: #frontend-infra-web

## Test plan:

All behaviour is covered by unit tests — no manual steps required.

## Review plan:

No High or Medium risk file changes. The only production-code change is a
focused guard clause in \`actions/fix-workflows/index.ts\` backed by full
test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)