### PR TITLE
secure-network: fix intermittent DNS failure on Ubuntu runners (resolv.conf symlink)

### DIFF
--- a/.changeset/secure-network-symlink-fix.md
+++ b/.changeset/secure-network-symlink-fix.md
@@ -1,0 +1,5 @@
+---
+"secure-network": patch
+---
+
+Fix intermittent DNS failures on GitHub-hosted runners caused by /etc/resolv.conf being a symlink to a tmpfs file managed by systemd-resolved. chattr +i is a no-op on tmpfs, so systemd-resolved could overwrite the file after setup. The symlink is now removed before writing, creating a real file on /etc (ext4) that chattr can lock.

--- a/actions/secure-network/secure-network.js
+++ b/actions/secure-network/secure-network.js
@@ -546,6 +546,21 @@ async function main() {
     }
 
     console.log("Redirecting DNS to local Unbound resolver...");
+    // On Ubuntu with systemd-resolved, /etc/resolv.conf is a symlink to
+    // /run/systemd/resolve/stub-resolv.conf on tmpfs. Writing through the symlink
+    // lets systemd-resolved silently overwrite our change, and chattr +i is a
+    // no-op on tmpfs (unsupported filesystem). Remove any existing symlink/file
+    // first so we create a real file on /etc (ext4), where chattr can lock it.
+    try {
+        if (fs.lstatSync("/etc/resolv.conf").isSymbolicLink()) {
+            fs.unlinkSync("/etc/resolv.conf");
+            console.log(
+                "  Removed /etc/resolv.conf symlink (was managed by systemd-resolved).",
+            );
+        }
+    } catch (_) {
+        /* not a symlink or doesn't exist — proceed */
+    }
     fs.writeFileSync("/etc/resolv.conf", "nameserver 127.0.0.1\n");
     // resolv.conf.bak is kept until process exit; the exit handler restores it on error.
 

--- a/actions/secure-network/secure-network.js
+++ b/actions/secure-network/secure-network.js
@@ -549,17 +549,16 @@ async function main() {
     // On Ubuntu with systemd-resolved, /etc/resolv.conf is a symlink to
     // /run/systemd/resolve/stub-resolv.conf on tmpfs. Writing through the symlink
     // lets systemd-resolved silently overwrite our change, and chattr +i is a
-    // no-op on tmpfs (unsupported filesystem). Remove any existing symlink/file
+    // no-op on tmpfs (unsupported filesystem). Remove any existing symlink
     // first so we create a real file on /etc (ext4), where chattr can lock it.
-    try {
-        if (fs.lstatSync("/etc/resolv.conf").isSymbolicLink()) {
-            fs.unlinkSync("/etc/resolv.conf");
-            console.log(
-                "  Removed /etc/resolv.conf symlink (was managed by systemd-resolved).",
-            );
-        }
-    } catch (_) {
-        /* not a symlink or doesn't exist — proceed */
+    if (
+        fs.existsSync("/etc/resolv.conf") &&
+        fs.lstatSync("/etc/resolv.conf").isSymbolicLink()
+    ) {
+        fs.unlinkSync("/etc/resolv.conf");
+        console.log(
+            "  Removed /etc/resolv.conf symlink (was managed by systemd-resolved).",
+        );
     }
     fs.writeFileSync("/etc/resolv.conf", "nameserver 127.0.0.1\n");
     // resolv.conf.bak is kept until process exit; the exit handler restores it on error.


### PR DESCRIPTION
## Summary

- Fixes intermittent DNS failures on GitHub-hosted runners where `secure-network` would set up Unbound correctly but DNS queries would still fail
- Root cause: on Ubuntu 24.04, `/etc/resolv.conf` is a symlink to `/run/systemd/resolve/stub-resolv.conf` on **tmpfs**. Writing through the symlink put our `nameserver 127.0.0.1` on tmpfs, where `chattr +i` is a no-op — so systemd-resolved could silently overwrite the file back to `nameserver 127.0.0.53`
- Fix: break the symlink before writing, so `/etc/resolv.conf` becomes a regular file on `/etc` (ext4), where `chattr +i` actually locks it

## How the failure manifested

Post-job diagnostics (added in #171) showed:
- Unbound was running fine (not crashed)
- `/etc/resolv.conf` contained `nameserver 127.0.0.53` (systemd-resolved's stub) instead of `nameserver 127.0.0.1`
- DNS test: `connection refused to 127.0.0.53#53` — systemd-resolved was stopped but iptables also REJECTs queries to `127.0.0.53` (only `127.0.0.1:53` is allowed)

## Why it was intermittent

systemd-resolved only rewrites its stub file in response to network events (DHCP renewals, interface changes, etc.). Most runs complete without such an event in the narrow window between our `writeFileSync` and the failed `chattr +i`, so it usually works. Occasionally a runner gets a network event mid-job and the file is overwritten.

## Test plan
- [ ] Run a workflow that uses `secure-network` and confirm the new log line appears: `Removed /etc/resolv.conf symlink (was managed by systemd-resolved).`
- [ ] Post-job diagnostics should now show `nameserver 127.0.0.1` in `/etc/resolv.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)