### PR TITLE
generate-terraform-plan: clarify scheduled PR body about image digest churn

### DIFF
--- a/.changeset/clarify-scheduled-plan-pr-body.md
+++ b/.changeset/clarify-scheduled-plan-pr-body.md
@@ -1,0 +1,5 @@
+---
+"generate-terraform-plan": patch
+---
+
+Clarify the scheduled-plan PR description: when the diff shows no code changes but the plan shows a Docker image digest change, explain that this is from an upstream base-image or OS-package update and is safe to merge. Replaces the previous (and confusing) instructions to dig through Cloud Build logs.

--- a/actions/generate-terraform-plan/action.yml
+++ b/actions/generate-terraform-plan/action.yml
@@ -205,9 +205,7 @@ runs:
           To evaluate this change:
           1. Check the plan output above to see what infrastructure changes are proposed
           2. Review the changes in the diff link above to understand what code or configuration changed
-          3 If there are changes to a docker image not explained by the diff:
-            1. Look at the [Cloud Build logs](https://console.cloud.google.com/cloud-build/builds) for the build that was triggered by this plan. Look for a build that has a start time just before this PR was created. The logs will contain the digest of the docker image in the plan output.
-            2. In the build logs, the first step that shows changes will indicate what changed in the docker image, e.g. an updated base image or package updates' || '' }}
+          3. If the diff shows no code changes but a Docker image digest changed in the plan, the rebuild was triggered by an upstream update — typically a new version of the base image being republished, or new versions of OS packages installed via the Dockerfile. The daily scheduled rebuild picks these up automatically so the deployed image stays on patched bases. This is expected and safe to merge.' || '' }}
         add-paths: |
           ${{ inputs.terraform_path }}/${{ inputs.plan_file_binary }}
           ${{ inputs.terraform_path }}/${{ inputs.plan_file_text }}


### PR DESCRIPTION
## Summary
- The "Scheduled Build Context" section of the auto-generated terraform-plan PR previously told reviewers to dig through Cloud Build logs whenever the plan showed only a Docker image digest change. In practice that case is almost always just an upstream republish of the base image (e.g. `python:3.11-slim`) or new versions of OS packages pulled in by the Dockerfile — the daily rebuild produces a new digest even though nothing in the repo changed.
- Replace the cloud-build-logs walkthrough with a one-sentence explanation that this case is expected and safe to merge.

Context: see [Khan/internal-services#514](https://github.com/Khan/internal-services/pull/514) for an example of a PR that triggered this confusion. The digest there changed because a new `python:3.11-slim` was republished upstream, which invalidated the Dockerfile cache and caused a fresh `apt-get install` against Debian trixie.

## Test plan
- [ ] Tag a new patch release of `generate-terraform-plan` (changeset included)
- [ ] Bump the action reference in `Khan/internal-services` `.github/workflows/build-github-actions-runner-terraform-plan.yml` to the new tag
- [ ] Wait for the next scheduled (cron) run and confirm the PR body shows the new wording