### PR TITLE
gerald-pr: update Khan/gerald to v5.2

### DIFF
--- a/.changeset/update-gerald-v52.md
+++ b/.changeset/update-gerald-v52.md
@@ -1,0 +1,5 @@
+---
+"gerald-pr": minor
+---
+
+Update to v5.2 of Khan/gerald action

--- a/actions/gerald-pr/action.yml
+++ b/actions/gerald-pr/action.yml
@@ -25,7 +25,7 @@ runs:
           ref: '${{ github.head_ref }}'
         if: ${{ github.event.pull_request.draft == false }}
       - name: Run Gerald
-        uses: Khan/gerald@0a9a99fe8c226708c01ef3bf5c85562a250bd851 # v5.1
+        uses: Khan/gerald@c3a58fd3c28007603557651b1079e3ab3362ec86 # v5.2
         env:
           GITHUB_TOKEN: '${{ inputs.token }}'
           ADMIN_PERMISSION_TOKEN: '${{ inputs.admin-token }}'


### PR DESCRIPTION
## Summary
- Update the `Khan/gerald` action pin from v5.1 to v5.2 in `actions/gerald-pr/action.yml`
- Add changeset for a minor version bump of `gerald-pr`

## Test plan
- [ ] Verify the new SHA (`c3a58fd3c28007603557651b1079e3ab3362ec86`) matches the `v5.2` tag on Khan/gerald
- [ ] Confirm Gerald runs correctly on a test PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)