### PR TITLE
secure-network: run apt-get update before installing packages

### DIFF
--- a/.changeset/warm-pandas-learn.md
+++ b/.changeset/warm-pandas-learn.md
@@ -1,0 +1,5 @@
+---
+"secure-network": patch
+---
+
+Run apt-get update before installing packages to ensure package lists are current.

--- a/actions/secure-network/secure-network.js
+++ b/actions/secure-network/secure-network.js
@@ -369,6 +369,7 @@ async function main() {
     if (pkgsNeeded.length > 0) {
         console.log(`Installing: ${pkgsNeeded.join(" ")}`);
         process.env.DEBIAN_FRONTEND = "noninteractive";
+        run("apt-get -y update");
         run(
             `apt-get install -y --no-install-recommends ${pkgsNeeded.join(
                 " ",


### PR DESCRIPTION
## Summary
- Adds `apt-get -y update` before `apt-get install` in the secure-network action's dependency installation step
- Ensures the package index is refreshed so installs don't fail due to stale package lists on GitHub runners or self-hosted Cloud Run runners
- Only runs when packages actually need installing (skipped when already present)

## Test plan
- [ ] Verify the secure-network action runs successfully on a GitHub-hosted runner
- [ ] Verify the secure-network action runs successfully on a self-hosted Cloud Run runner
- [ ] Confirm no regressions when packages are already installed (apt-get update is skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)