### PR TITLE
Make runs-on check more permissive, to only check for a suffix

### DIFF
--- a/.changeset/fluffy-apes-shake.md
+++ b/.changeset/fluffy-apes-shake.md
@@ -1,0 +1,5 @@
+---
+"fix-workflows": minor
+---
+
+Make the 'runs-on' check more permissive, only checking a suffix instead of the whole line

--- a/actions/fix-workflows/index.test.ts
+++ b/actions/fix-workflows/index.test.ts
@@ -517,6 +517,16 @@ jobs:
             false,
         ],
         [
+            "returns false for a matrix-specific runner conditional expression",
+            `
+jobs:
+  build:
+    runs-on: "\${{ (matrix.language == 'go' && matrix.type == 'tests') && 'ubuntu-latest' || vars.USE_GITHUB_RUNNERS == 'true' && 'ubuntu-latest' || 'ephemeral-runner' }}"
+    steps: []
+`,
+            false,
+        ],
+        [
             "returns true for a plain ubuntu-latest string",
             `
 jobs:

--- a/actions/fix-workflows/index.ts
+++ b/actions/fix-workflows/index.ts
@@ -31,7 +31,7 @@ const YAML_WRITE_OPTIONS = {indent: 4, lineWidth: 0} as const;
 
 /** Matches the required conditional runs-on expression (any runner name). */
 const VALID_RUNS_ON_RE =
-    /vars\.USE_GITHUB_RUNNERS\s*==\s*'true'\s*&&\s*'[^']+'\s*\|\|\s*'ephemeral-runner'\s*\}\}$/;
+    /vars\.USE_GITHUB_RUNNERS\s*==\s*'true'\s*&&\s*'[^']+'\s*\|\|\s*'ephemeral-runner[\w-]*'\s*\}\}$/;
 
 // ---------------------------------------------------------------------------
 // File discovery

--- a/actions/fix-workflows/index.ts
+++ b/actions/fix-workflows/index.ts
@@ -31,7 +31,7 @@ const YAML_WRITE_OPTIONS = {indent: 4, lineWidth: 0} as const;
 
 /** Matches the required conditional runs-on expression (any runner name). */
 const VALID_RUNS_ON_RE =
-    /^\$\{\{\s*vars\.USE_GITHUB_RUNNERS\s*==\s*'true'\s*&&\s*'[^']+'\s*\|\|\s*'ephemeral-runner'\s*\}\}$/;
+    /vars\.USE_GITHUB_RUNNERS\s*==\s*'true'\s*&&\s*'[^']+'\s*\|\|\s*'ephemeral-runner'\s*\}\}$/;
 
 // ---------------------------------------------------------------------------
 // File discovery


### PR DESCRIPTION
## Summary:
In webapp/webapp-test.yml we want to use github runners for go tests to hopefully address some reliability issues. We'll have the "USE_GITHUB_RUNNERS" thing at the end of the 'runs-on', but we need something else at the start.

```
        runs-on: "${{ (matrix.language == 'go' && matrix.type == 'tests') && 'ubuntu-latest' || vars.USE_GITHUB_RUNNERS == 'true' && 'ubuntu-latest' || 'ephemeral-runner' }}"
```

Issue: <url or "none">

## Test plan:
<see below>