### PR TITLE
review: add explicit name to each inline sub-agent

### DIFF
--- a/.changeset/add-subagent-names.md
+++ b/.changeset/add-subagent-names.md
@@ -1,0 +1,5 @@
+---
+"review": patch
+---
+
+Add an explicit `name:` to each inline sub-agent's frontmatter (`correctness-reviewer`, `skill-auditor`, `pattern-triage`, `reviewer-mapper`, `thread-reconciler`, `claim-validator`). Recent gh-aw/Claude engine versions require sub-agents to declare a `name` rather than inferring it from the `## agent:` header, so without this the compiled workflow fails to dispatch them.

--- a/workflows/review/review.md
+++ b/workflows/review/review.md
@@ -628,6 +628,7 @@ Save to `/tmp/gh-aw/cache-memory/pr-${{ github.event.pull_request.number || gith
 
 ## agent: `correctness-reviewer`
 ---
+name: correctness-reviewer
 description: Classifies each changed file's risk and reviews the diff for correctness defects; returns JSON.
 model: opus
 ---
@@ -673,6 +674,7 @@ and high-signal; use a blocking label only for a defect CI would not catch.
 
 ## agent: `skill-auditor`
 ---
+name: skill-auditor
 description: Evaluates the diff against the repo's best-practice skills and returns violations as JSON.
 model: opus
 ---
@@ -707,6 +709,7 @@ return {"violations": []}.
 
 ## agent: `pattern-triage`
 ---
+name: pattern-triage
 description: Finds common cross-file patterns and returns the files that still need a real review.
 model: large
 ---
@@ -748,6 +751,7 @@ Return ONLY this JSON object (no prose, no code fence):
 
 ## agent: `reviewer-mapper`
 ---
+name: reviewer-mapper
 description: Maps changed files to owning team(s) via .github/REVIEWERS and ranks teams by how much of the change they own.
 model: small
 ---
@@ -777,6 +781,7 @@ Return ONLY this JSON object (no prose, no code fence):
 
 ## agent: `thread-reconciler`
 ---
+name: thread-reconciler
 description: Decides which of the workflow's earlier review threads the current code has addressed; returns thread ids.
 model: opus
 ---
@@ -799,6 +804,7 @@ Every input `thread_id` must appear in exactly one of the two lists.
 
 ## agent: `claim-validator`
 ---
+name: claim-validator
 description: Re-checks each candidate review comment against the actual code and the repo's best-practice skills, and drops or corrects the ones that are wrong; returns JSON.
 model: opus
 ---


### PR DESCRIPTION
## What

Add an explicit `name:` field to the frontmatter of all six inline sub-agents in the shared `review` workflow:

- `correctness-reviewer`
- `skill-auditor`
- `pattern-triage`
- `reviewer-mapper`
- `thread-reconciler`
- `claim-validator`

Each `name:` matches the slug already in its `## agent:` header. Also adds a `patch` changeset for the `review` package.

## Why

Recent gh-aw / Claude engine versions require each inline sub-agent to declare a `name:` in its frontmatter rather than inferring it from the `## agent:` header. Without it, the compiled workflow fails to dispatch the sub-agents.

This `actions` repo is the source of truth for the workflow, so the fix belongs here and will propagate to consumers on their next `gh aw compile`. It mirrors the change that had to be applied downstream in [Khan/frontend#13085](https://github.com/Khan/frontend/pull/13085) (commit `711e160`).

## Notes for reviewers

- Only the sub-agent frontmatter changed — no behavioral/prompt changes.
- The frontend PR that surfaced this also bumped gh-aw `v0.79.6 → v0.82.0`. If the `name:` requirement is tied to that newer compiler, consumers pick up this fix only once they regenerate against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)