### PR TITLE
fix-workflows: support inline `fix-workflows-ignore` comments

### DIFF
--- a/.changeset/fix-workflows-ignore-comments.md
+++ b/.changeset/fix-workflows-ignore-comments.md
@@ -1,0 +1,14 @@
+---
+"fix-workflows": minor
+---
+
+Support inline `# fix-workflows-ignore` comments to opt a job or checkout step out of a fix.
+
+Some jobs legitimately need a specific runner (e.g. `runs-on: ubuntu-latest-m`) or intentionally skip the secure-network setup step, but the fixer previously rewrote them unconditionally. You can now annotate the exact line to opt out:
+
+- On a `runs-on:` line (trailing, or as the job's leading comment) to skip the runs-on rewrite:
+  `runs-on: ubuntu-latest-m # fix-workflows-ignore`
+- On a checkout step (trailing on its `uses:` line, or as the step's leading comment) to skip inserting the setup step after it:
+  `uses: actions/checkout@v4 # fix-workflows-ignore`
+
+An unscoped directive skips every rule for the annotated line; a scoped directive names which rules to skip (`# fix-workflows-ignore: runs-on`, `# fix-workflows-ignore: setup`, or both). `# lintignore` is accepted as an alias.

--- a/actions/fix-workflows/action.yml
+++ b/actions/fix-workflows/action.yml
@@ -2,7 +2,8 @@ name: Fix Workflows
 description: >-
     Validates and auto-fixes GitHub Actions workflow YAML files
     (checkout-followed-by-setup and optionally runs-on patterns), then
-    formats them with oxfmt.
+    formats them with oxfmt. A `# fix-workflows-ignore` comment on a
+    `runs-on:` line or a checkout step opts that job/step out of the fix.
 inputs:
     fix-runs-on:
         description: >-
@@ -52,7 +53,8 @@ runs:
                 TAG="fix-workflows-v${MAJOR_VERSION}"
                 ARGS="${{ inputs.fix-runs-on == 'true' && ' --fix-runs-on' || '' }} --setup-action '${{ inputs.setup-action }}'"
                 CMD="pnpm dlx github:Khan/actions#${TAG}${ARGS}"
+                HINT="Or add a '# fix-workflows-ignore' comment to the runs-on line or checkout step to opt out."
                 for file in $(git diff --name-only .github/workflows/); do
-                  echo "::warning file=${file}::This file needs updating. Run: ${CMD}"
+                  echo "::warning file=${file}::This file needs updating. Run: ${CMD} ${HINT}"
                 done
               fi

--- a/actions/fix-workflows/index.test.ts
+++ b/actions/fix-workflows/index.test.ts
@@ -10,6 +10,8 @@ import {
     fixSteps,
     isExemptRunner,
     processJob,
+    runsOnIgnored,
+    stepIgnoresSetup,
 } from "./index.ts";
 
 // ---------------------------------------------------------------------------
@@ -442,6 +444,163 @@ jobs:
 // ---------------------------------------------------------------------------
 // Helpers for runs-on tests
 // ---------------------------------------------------------------------------
+
+/** Parse a YAML string and return the first step map from jobs.<id>.steps */
+function parseFirstStep(yaml: string) {
+    const {steps} = parseWorkflowSteps(yaml);
+    const step = steps.items[0];
+    if (!isMap(step)) {
+        throw new Error("Expected a step map");
+    }
+    return step;
+}
+
+// ---------------------------------------------------------------------------
+// Ignore directives
+// ---------------------------------------------------------------------------
+
+describe("runsOnIgnored", () => {
+    // Each suffix is spliced onto `runs-on: ubuntu-latest-m<suffix>`.
+    it.each([
+        [" # fix-workflows-ignore", true],
+        [" # fix-workflows-ignore: runs-on", true],
+        [" # lintignore", true],
+        [" # fix-workflows-ignore: runs-on, setup", true],
+        [" # fix-workflows-ignore: setup", false],
+        ["", false],
+    ])("runs-on%s => %s", (suffix, expected) => {
+        const job = parseWorkflowJob(`
+jobs:
+  build:
+    runs-on: ubuntu-latest-m${suffix}
+    steps: []
+`);
+        expect(runsOnIgnored(job)).toBe(expected);
+    });
+
+    it("returns true for a job-level directive above the runs-on line", () => {
+        const job = parseWorkflowJob(`
+jobs:
+  build:
+    # fix-workflows-ignore
+    runs-on: ubuntu-latest-m
+    steps: []
+`);
+        expect(runsOnIgnored(job)).toBe(true);
+    });
+});
+
+describe("checkRunsOn and fixRunsOn with ignore directives", () => {
+    it("treats an ignored plain runner as compliant and leaves it untouched", () => {
+        const job = parseWorkflowJob(`
+jobs:
+  build:
+    runs-on: ubuntu-latest-m # fix-workflows-ignore
+    steps: []
+`);
+        expect(checkRunsOn(job)).toBe(false);
+        expect(fixRunsOn(job)).toBe(false);
+        expect(job.get("runs-on")).toBe("ubuntu-latest-m");
+    });
+});
+
+describe("stepIgnoresSetup", () => {
+    // Each suffix is spliced onto `uses: actions/checkout@v4<suffix>`.
+    it.each([
+        [" # fix-workflows-ignore", true],
+        [" # fix-workflows-ignore: setup", true],
+        [" # fix-workflows-ignore: runs-on", false],
+        ["", false],
+    ])("checkout uses%s => %s", (suffix, expected) => {
+        const step = parseFirstStep(`
+jobs:
+  build:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4${suffix}
+`);
+        expect(stepIgnoresSetup(step)).toBe(expected);
+    });
+});
+
+describe("fixSteps with ignore directives", () => {
+    it("does not insert a setup step after an ignored checkout", () => {
+        const {doc, steps} = parseWorkflowSteps(`
+jobs:
+  build:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4 # fix-workflows-ignore
+      - name: Build
+        run: pnpm build
+`);
+        const result = fixSteps(doc, steps);
+        expect(result).toBe(false);
+        expect(steps.items).toHaveLength(2);
+    });
+
+    it("still inserts setup for a non-ignored checkout alongside an ignored one", () => {
+        const {doc, steps} = parseWorkflowSteps(`
+jobs:
+  build:
+    steps:
+      - name: Exempt Checkout
+        uses: actions/checkout@v4 # fix-workflows-ignore
+      - name: Guarded Checkout
+        uses: actions/checkout@v4
+`);
+        const result = fixSteps(doc, steps);
+        expect(result).toBe(true);
+        // Only the second checkout gains a setup step.
+        expect(steps.items).toHaveLength(3);
+        expect((steps.items[2] as any).get("uses")).toBe(DEFAULT_SETUP_ACTION);
+    });
+});
+
+describe("checkSteps with ignore directives", () => {
+    it("returns false for an ignored checkout that lacks a setup step", () => {
+        const {steps} = parseWorkflowSteps(`
+jobs:
+  build:
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4 # fix-workflows-ignore
+      - name: Build
+        run: pnpm build
+`);
+        expect(checkSteps(steps)).toBe(false);
+    });
+});
+
+describe("processJob and checkJob with ignore directives", () => {
+    it("does not rewrite an ignored runs-on when shouldFixRunsOn is true", () => {
+        const {doc, job} = parseWorkflowJobWithDoc(`
+jobs:
+  build:
+    runs-on: ubuntu-latest-m # fix-workflows-ignore
+    steps: []
+`);
+        expect(processJob(doc, job, {shouldFixRunsOn: true})).toBe(false);
+        expect(job.get("runs-on")).toBe("ubuntu-latest-m");
+        expect(checkJob(job, {shouldFixRunsOn: true})).toBe(false);
+    });
+
+    it("does not insert a setup step for a checkout with a setup-scoped ignore", () => {
+        const {doc, job} = parseWorkflowJobWithDoc(`
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4 # fix-workflows-ignore: setup
+      - name: Build
+        run: pnpm build
+`);
+        expect(processJob(doc, job)).toBe(false);
+        expect(checkJob(job)).toBe(false);
+        expect(job.toJSON().steps).toHaveLength(2);
+    });
+});
 
 /** Parse a YAML string and return the first job's map node. */
 function parseWorkflowJob(yaml: string) {

--- a/actions/fix-workflows/index.ts
+++ b/actions/fix-workflows/index.ts
@@ -10,6 +10,9 @@
  * When a violation is found it is fixed automatically.
  * Comments are preserved via the yaml package's document API.
  * Run oxfmt after this script to normalize formatting.
+ *
+ * Individual jobs, `runs-on:` lines, or checkout steps can opt out of a fix
+ * with an inline `fix-workflows-ignore` comment — see IGNORE_DIRECTIVE_RE.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -19,6 +22,7 @@ import {
     isSeq,
     parseDocument,
     type Document,
+    type Node,
     type YAMLMap,
     type YAMLSeq,
 } from "yaml";
@@ -32,6 +36,143 @@ const YAML_WRITE_OPTIONS = {indent: 4, lineWidth: 0} as const;
 /** Matches the required conditional runs-on expression (any runner name). */
 const VALID_RUNS_ON_RE =
     /vars\.USE_GITHUB_RUNNERS\s*==\s*'true'\s*&&\s*'[^']+'\s*\|\|\s*'ephemeral-runner[\w-]*'\s*\}\}$/;
+
+// ---------------------------------------------------------------------------
+// Ignore directives
+// ---------------------------------------------------------------------------
+
+/** The fixes an ignore directive can suppress. */
+export type IgnoreRule = "runs-on" | "setup";
+
+const ALL_IGNORE_RULES: readonly IgnoreRule[] = ["runs-on", "setup"];
+
+/**
+ * Matches an ignore directive inside a single line of a YAML comment. The
+ * optional list after the `:` names which rules to skip; when absent, every
+ * rule is skipped for the annotated node. `lintignore` is accepted as an
+ * alias for `fix-workflows-ignore`. Examples:
+ *
+ *   # fix-workflows-ignore
+ *   # fix-workflows-ignore: runs-on
+ *   # fix-workflows-ignore: runs-on, setup
+ *   # lintignore
+ */
+const IGNORE_DIRECTIVE_RE =
+    /(?:fix-workflows-ignore|lintignore)(?:\s*[:=]\s*([a-z0-9,\s_-]+))?/i;
+
+/** Map a rule token from a directive to its canonical IgnoreRule, or null. */
+function normalizeRule(token: string): IgnoreRule | null {
+    switch (token.trim().toLowerCase()) {
+        case "runs-on":
+        case "runson":
+        case "runs_on":
+            return "runs-on";
+        case "setup":
+        case "secure-network":
+        case "checkout":
+            return "setup";
+        default:
+            return null;
+    }
+}
+
+/**
+ * Parse a single comment line for an ignore directive. Returns the set of
+ * rules it suppresses, or null when the line contains no directive. An
+ * unscoped directive (or one that names only unrecognized rules) suppresses
+ * every rule.
+ */
+function parseDirectiveLine(line: string): Set<IgnoreRule> | null {
+    const match = line.match(IGNORE_DIRECTIVE_RE);
+    if (!match) {
+        return null;
+    }
+    const spec = match[1]?.trim();
+    if (!spec) {
+        return new Set(ALL_IGNORE_RULES);
+    }
+    const rules = new Set<IgnoreRule>();
+    for (const token of spec.split(/[,\s]+/)) {
+        const rule = normalizeRule(token);
+        if (rule) {
+            rules.add(rule);
+        }
+    }
+    // A directive that names only unrecognized rules is treated as unscoped
+    // rather than silently doing nothing — the author clearly wants to skip.
+    return rules.size > 0 ? rules : new Set(ALL_IGNORE_RULES);
+}
+
+/**
+ * Collect the ignore rules requested by the `comment` and `commentBefore`
+ * annotations on any of the given nodes. `commentBefore` may span multiple
+ * lines, so each line is inspected. Returns null when no directive is found.
+ */
+function directiveFrom(
+    ...nodes: Array<Node | null | undefined>
+): Set<IgnoreRule> | null {
+    const merged = new Set<IgnoreRule>();
+    let found = false;
+    for (const node of nodes) {
+        if (!node) {
+            continue;
+        }
+        for (const raw of [node.comment, node.commentBefore]) {
+            if (typeof raw !== "string") {
+                continue;
+            }
+            for (const line of raw.split("\n")) {
+                const rules = parseDirectiveLine(line);
+                if (rules) {
+                    found = true;
+                    for (const rule of rules) {
+                        merged.add(rule);
+                    }
+                }
+            }
+        }
+    }
+    return found ? merged : null;
+}
+
+/** Return the key and value nodes of `map`'s pair whose key is `keyName`. */
+function pairNodes(map: YAMLMap, keyName: string): Node[] {
+    const nodes: Node[] = [];
+    for (const item of map.items) {
+        const pair = item as {key?: Node; value?: Node};
+        if ((pair.key as any)?.value === keyName) {
+            if (pair.key) {
+                nodes.push(pair.key);
+            }
+            if (pair.value) {
+                nodes.push(pair.value);
+            }
+        }
+    }
+    return nodes;
+}
+
+/**
+ * Return true if the runs-on fix is suppressed for `job` by an ignore
+ * directive on the `runs-on:` line (trailing or immediately above it) or on
+ * the job's leading comment.
+ */
+export function runsOnIgnored(job: YAMLMap): boolean {
+    return (
+        directiveFrom(job, ...pairNodes(job, "runs-on"))?.has("runs-on") ??
+        false
+    );
+}
+
+/**
+ * Return true if the setup-step fix is suppressed for a checkout `step` by an
+ * ignore directive on the step (its leading comment) or on its `uses:` line.
+ */
+export function stepIgnoresSetup(step: YAMLMap): boolean {
+    return (
+        directiveFrom(step, ...pairNodes(step, "uses"))?.has("setup") ?? false
+    );
+}
 
 // ---------------------------------------------------------------------------
 // File discovery
@@ -96,6 +237,11 @@ export function fixSteps(
             continue;
         }
 
+        // Skip checkouts that opt out via an inline ignore directive.
+        if (stepIgnoresSetup(step)) {
+            continue;
+        }
+
         const nextStep = steps.items[i + 1];
         const nextUses = isMap(nextStep)
             ? String(nextStep.get("uses") ?? "")
@@ -150,6 +296,10 @@ export function checkSteps(
         if (!uses.startsWith("actions/checkout")) {
             continue;
         }
+        // Skip checkouts that opt out via an inline ignore directive.
+        if (stepIgnoresSetup(step)) {
+            continue;
+        }
         const nextUses = isMap(steps.items[i + 1])
             ? String((steps.items[i + 1] as any).get("uses") ?? "")
             : "";
@@ -179,6 +329,11 @@ export function checkRunsOn(job: YAMLMap): boolean {
         return false;
     }
     if (isExemptRunner(job)) {
+        return false;
+    }
+    // An explicit ignore directive opts the job out of the runs-on fix, so
+    // treat it as compliant. This gates fixRunsOn too, which calls checkRunsOn.
+    if (runsOnIgnored(job)) {
         return false;
     }
     return !VALID_RUNS_ON_RE.test(runsOn);


### PR DESCRIPTION
## Summary

The `fix-workflows` action rewrites every `runs-on:` to the conditional `ephemeral-runner` expression (when `fix-runs-on` is enabled) and inserts a secure-network setup step after every `actions/checkout`. Some jobs legitimately need a specific runner — e.g. [Khan/webapp#40211](https://github.com/Khan/webapp/pull/40211) needs to route go-test shards to a dedicated runner and, more generally, a job may need `runs-on: ubuntu-latest-m` — or intentionally skip the setup step, but there was previously no way to opt out.

This adds an inline escape hatch, anchored to the exact line being changed (like `# noqa` / `// eslint-disable-line`):

- **runs-on:** `runs-on: ubuntu-latest-m # fix-workflows-ignore` — skips the runs-on rewrite for that job.
- **setup step:** `uses: actions/checkout@v4 # fix-workflows-ignore` — skips inserting the setup step after that checkout.

Directives can be **unscoped** (skip every rule for the annotated line) or **scoped** to a specific rule: `# fix-workflows-ignore: runs-on`, `# fix-workflows-ignore: setup`, or `# fix-workflows-ignore: runs-on, setup`. `# lintignore` is accepted as an alias. A directive may also be placed as the leading comment of the job (for runs-on) or the checkout step (for setup) instead of trailing the line.

## Changes
- **`index.ts`** — parse `fix-workflows-ignore` directives from YAML comments (`comment` / `commentBefore`) and honor them: `checkRunsOn` (which also gates `fixRunsOn` and the verify pass) returns "compliant" when the runs-on line opts out; `fixSteps`/`checkSteps` skip any checkout whose step or `uses:` line opts out. New exported helpers `runsOnIgnored` and `stepIgnoresSetup`.
- **`index.test.ts`** — coverage for trailing and leading placements, scoped vs unscoped directives, the `lintignore` alias, per-checkout granularity (one ignored checkout doesn't exempt a sibling), and the `processJob`/`checkJob` integration paths.
- **`action.yml`** — mention the opt-out in the action description and in the per-file "needs updating" warning.
- **`.changeset/`** — minor changeset (the release workflow bumps the version and CHANGELOG on landing).

## Verification
- `npx vitest run` — 183 passing (55 in `fix-workflows`, 17 new).
- `tsc --noEmit` and `eslint` clean.
- End-to-end run of the action's entrypoint against a fixture: a plain `runs-on: ubuntu-latest` job is fully rewritten while a `runs-on: ubuntu-latest-m # fix-workflows-ignore` job (with an ignored checkout) is left untouched, comments preserved, and the post-fix verify pass reports no remaining violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TP92sbdHXuVE5skDCAt2fm

---
_Generated by [Claude Code](https://claude.ai/code/session_01TP92sbdHXuVE5skDCAt2fm)_