### PR TITLE
fix(apply-terraform-plan): regenerate data-source artifacts before applying saved plan

### DIFF
--- a/.changeset/apply-regenerate-archive-artifacts.md
+++ b/.changeset/apply-regenerate-archive-artifacts.md
@@ -1,0 +1,9 @@
+---
+"apply-terraform-plan": patch
+---
+
+Regenerate data-source side-effect artifacts before applying a saved plan, so applies that (re)upload a Cloud Function/Cloud Run source bundle no longer fail on a fresh runner.
+
+The plan and apply jobs run on different runners. During `generate-terraform-plan`, an `archive_file` data source writes the function source zip to disk; the saved `tfplan.binary` records the resulting `google_storage_bucket_object` (`source = <local zip path>`). But `terraform apply <saved-plan>` does **not** re-evaluate data sources, so on the fresh apply runner that zip was never written and the apply fails with `open .../<job>-function.zip: no such file or directory`. This only surfaces when the archive actually changes (i.e. a source-code change) — metadata/IAM-only applies don't read the missing file, which is why it stayed hidden.
+
+The apply action now runs a throwaway `terraform plan` after `init` (non-`auto_approve` mode only) to re-materialize those local files, then applies the saved binary unchanged. The step is best-effort (`continue-on-error`): if it can't run (e.g. a required `TF_VAR_*` is only set in the plan workflow), the apply proceeds exactly as before, so this can never regress an apply that works today.

--- a/actions/apply-terraform-plan/action.yml
+++ b/actions/apply-terraform-plan/action.yml
@@ -93,6 +93,23 @@ runs:
       working-directory: ${{ inputs.terraform_path }}
       run: terraform init -input=false
 
+    # Regenerate local files that are produced as a side effect of reading data
+    # sources -- e.g. the `archive_file` zips referenced by a resource's
+    # `source` (Cloud Function/Cloud Run source bundles). Applying a *saved*
+    # plan skips data-source evaluation, so on a fresh apply runner (a different
+    # machine than the one that generated the plan) those files don't exist and
+    # the apply fails with "open ...zip: no such file or directory". A throwaway
+    # plan re-materializes them; it does not change what the saved binary
+    # applies below. Best-effort (continue-on-error): if it can't run (e.g. a
+    # required TF_VAR is only set in the plan workflow), the apply step still
+    # runs and behaves exactly as it did before this step existed.
+    - name: Regenerate data-source artifacts
+      if: steps.check_files.outputs.skip_apply != 'true' && inputs.auto_approve != 'true'
+      shell: bash
+      working-directory: ${{ inputs.terraform_path }}
+      continue-on-error: true
+      run: terraform plan -input=false -out=/dev/null
+
     - name: Apply Terraform Plan
       if: steps.check_files.outputs.skip_apply != 'true'
       id: apply


### PR DESCRIPTION
## Problem

Applies that (re)upload a Cloud Function / Cloud Run **source bundle** fail on the apply runner with:

```
Error: open .terraform/modules/<name>/terraform/modules/scheduled-job/<job>-function.zip: no such file or directory
```

Root cause is the plan/apply split across runners:

- `generate-terraform-plan` runs `terraform plan -out=tfplan.binary`. During that plan, an `archive_file` **data source** writes the function source zip to disk (`output_path`), and the saved plan records a `google_storage_bucket_object` whose `source` is that local path.
- `apply-terraform-plan` runs `terraform apply <saved-plan>` on a **different, fresh runner**. Applying a *saved* plan does **not** re-evaluate data sources, so the zip is never written there — and the upload fails because its `source` file is missing.

It only surfaces when the archive actually changes (a source-code change forces the object to be replaced). Metadata/IAM-only applies don't read the missing file, which is why this stayed latent until now.

This bit a real deploy in `Khan/beep-boop` (`zendesk-reports`, using `terraform-modules//scheduled-job`): the apply died at the archive upload **after** already applying the unrelated IAM changes, leaving the stack half-migrated (the runtime SA's grant on the old secret was destroyed while the function still referenced it). So beyond the failed deploy, the partial apply is itself hazardous.

## Fix

After `terraform init`, run a **throwaway `terraform plan`** (non-`auto_approve` mode only) to re-materialize the data-source side-effect files, then apply the saved binary unchanged. The plan output goes to `/dev/null` (Linux runners) — we only want the side effect of writing the zip, not the plan itself.

The step is **best-effort** (`continue-on-error: true`): if it can't run — e.g. a required `TF_VAR_*` is only set in the plan workflow, not the apply workflow — the apply step runs exactly as it does today. So this **cannot regress** an apply that currently works; it can only fix ones that are currently broken.

## Alternatives considered

- **Carry the built zip between the plan and apply jobs** (as an artifact/commit): fragile — the apply action doesn't know the module-internal `output_path`.
- **Fix in `terraform-modules//scheduled-job`**: `archive_file` + `google_storage_bucket_object.source = <local path>` is idiomatic and works fine with a normal apply; the breakage is entirely the saved-plan-across-runners pattern, so the fix belongs here.

## Test plan

- `action.yml` validated as YAML; step indentation matches the surrounding steps.
- Verified locally against `beep-boop/terraform/zendesk-reports` that a bare `terraform apply <saved-plan>` fails with the missing-zip error, while running `terraform plan` first regenerates `<job>-function.zip` on disk and a subsequent apply succeeds.

Changeset included (`apply-terraform-plan`: patch).