### PR TITLE
review: unblock first-principles (Fable 5 pricing) and harden the artifact-upload path

### DIFF
--- a/.changeset/review-fable-pricing-upload-path.md
+++ b/.changeset/review-fable-pricing-upload-path.md
@@ -1,0 +1,5 @@
+---
+"review": patch
+---
+
+Fix two failures observed on the first production run of review-v1.2.0. The first-principles reviewer failed on every dispatch: its pinned model (claude-fable-5) is not in the AI-credits pricing table bundled with gh-aw <= v0.81.x, so the cost-guardrail API proxy rejected the request with a 400 before it reached the model. The shared frontmatter now merges the model's pricing in via the `models:` field (values matching the curated entry upstream added in gh-aw-firewall v0.27.27), to be removed once gh-aw bundles Claude 5 pricing. Second, the Step 9 artifact-upload instruction now requires the absolute path `/tmp/gh-aw/review/out/`; an orchestrator that passed a relative `out` failed safe-output validation ("no files matched") even though the files existed. The lib-checkout ref is bumped to the release this ships in.

--- a/workflows/review/review.md
+++ b/workflows/review/review.md
@@ -138,6 +138,24 @@ engine:
   model: claude-opus-4-8
 timeout-minutes: 20
 
+# claude-fable-5 (the first-principles reviewer's pinned model) is not yet in the
+# AI-credits pricing table bundled with gh-aw <= v0.81.x, and the cost-guardrail API
+# proxy rejects any un-priced model with a 400, so the first-principles dispatch fails
+# on every run where it is enabled. Merge its pricing in here (per-token USD; values
+# match the curated entry upstream added in gh-aw-firewall v0.27.27: $10/M input,
+# $1/M cache read, $12.50/M cache write, $50/M output). Remove this block once the
+# workflow runs on a gh-aw release whose bundled table includes the Claude 5 family.
+models:
+  providers:
+    anthropic:
+      models:
+        claude-fable-5:
+          cost:
+            input: 1.0e-05
+            output: 5.0e-05
+            cache_read: 1.0e-06
+            cache_write: 1.25e-05
+
 # The shared review workflow is more than this markdown file: its deterministic
 # pieces (the finding schema and validator today; the router, computed verdict, and
 # comment renderer as they land) are TypeScript under `workflows/review/lib/` in
@@ -154,7 +172,7 @@ pre-agent-steps:
     uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     with:
       repository: Khan/actions
-      ref: review-v1.1.1
+      ref: review-v1.2.1
       path: gh-aw-review-lib
       persist-credentials: false
 
@@ -1089,7 +1107,11 @@ Save to `/tmp/gh-aw/cache-memory/pr-${{ github.event.pull_request.number || gith
 
 Finally, if you wrote any sub-agent outputs to `/tmp/gh-aw/review/out/` this run
 (Step 3), upload that directory as a run-scoped artifact with the `upload-artifact`
-safe output (`path: /tmp/gh-aw/review/out/`). This captures each reviewer's structured
+safe output. The `path` you pass MUST be the absolute path `/tmp/gh-aw/review/out/` —
+never a relative path like `out`, whatever your current working directory is: the
+safe-outputs processor validates the recorded path against the workflow's
+`allowed-paths` (`/tmp/gh-aw/review/out/**`), so a relative path fails validation with
+"no files matched" even when the files exist. This captures each reviewer's structured
 result for later inspection. Skip it only on an early exit (Step 2) where no sub-agents
 ran and the directory is empty.
 


### PR DESCRIPTION
Fixes two failures observed on the first production run of review-v1.2.0 (webapp, Khan/webapp#40678):

1. **first-principles failed on every dispatch.** Its pinned model `claude-fable-5` is not in the AI-credits pricing table bundled with gh-aw <= v0.81.x, so the cost-guardrail API proxy rejected the request with `400 Model "claude-fable-5" has no AI credits pricing` before it reached the model (11 instant retries, 0 tokens). The frontmatter now merges the model's pricing via gh-aw's `models:` field, using the same numbers upstream added to gh-aw-firewall v0.27.27 ($10/M input, $1/M cache read, $12.50/M cache write, $50/M output; expressed per token as the field requires). The block is commented for removal once the workflow runs on a gh-aw release whose bundled table includes the Claude 5 family.

2. **The Step 9 artifact upload failed validation.** The orchestrator ran the upload from inside `/tmp/gh-aw/review/out` and recorded the relative path `out`, which the safe-outputs processor could not match against `allowed-paths` (`/tmp/gh-aw/review/out/**`), producing `ERR_VALIDATION: no files matched the selection criteria` (the files still reached the artifact via staging, so this was an error annotation rather than data loss). The instruction now requires the absolute path explicitly.

Also bumps the lib-checkout ref to `review-v1.2.1`, the release this ships in.