### PR TITLE
review: pin the firewall to v0.27.27 so the api-proxy prices claude-fable-5

### DIFF
--- a/.changeset/review-firewall-pin-fable.md
+++ b/.changeset/review-firewall-pin-fable.md
@@ -1,0 +1,5 @@
+---
+"review": patch
+---
+
+Actually unblock the first-principles reviewer: the review-v1.2.1 `models:` pricing block only feeds gh-aw's cost-summary display and never reaches the firewall api-proxy's AI-credits guard, which kept rejecting claude-fable-5 with a 400. The frontmatter now pins `sandbox.agent.version` to gh-aw-firewall v0.27.27, the release whose api-proxy bundles curated Claude 5 pricing; the `models:` block stays so cost accounting shows the same numbers. Both are marked for removal once gh-aw's default firewall is v0.27.27 or newer. The lib-checkout ref is bumped to the release this ships in.

--- a/workflows/review/review.md
+++ b/workflows/review/review.md
@@ -138,13 +138,28 @@ engine:
   model: claude-opus-4-8
 timeout-minutes: 20
 
-# claude-fable-5 (the first-principles reviewer's pinned model) is not yet in the
-# AI-credits pricing table bundled with gh-aw <= v0.81.x, and the cost-guardrail API
-# proxy rejects any un-priced model with a 400, so the first-principles dispatch fails
-# on every run where it is enabled. Merge its pricing in here (per-token USD; values
-# match the curated entry upstream added in gh-aw-firewall v0.27.27: $10/M input,
-# $1/M cache read, $12.50/M cache write, $50/M output). Remove this block once the
-# workflow runs on a gh-aw release whose bundled table includes the Claude 5 family.
+# claude-fable-5 (the first-principles reviewer's pinned model) is not in the
+# AI-credits pricing table of the firewall api-proxy that gh-aw <= v0.81.x pins
+# (gh-aw-firewall v0.27.11), and the proxy rejects any un-priced model with a 400,
+# so the first-principles dispatch fails on every run where it is enabled. Two
+# pieces fix that, and BOTH pin to the same upstream source of truth
+# (gh-aw-firewall v0.27.27, the release that added curated Claude 5 pricing:
+# $10/M input, $1/M cache read, $12.50/M cache write, $50/M output):
+#
+# 1. `sandbox.agent.version` below runs that firewall version, whose api-proxy
+#    guard knows the model. This is the piece that actually unblocks the dispatch;
+#    the `models:` frontmatter only feeds gh-aw's cost-summary display and does
+#    NOT reach the proxy guard (verified empirically on gh-aw v0.81.6).
+# 2. The `models:` block keeps the run's cost accounting/display correct for the
+#    same model.
+#
+# Remove both once the workflow runs on a gh-aw release whose default firewall
+# is >= v0.27.27.
+sandbox:
+  agent:
+    id: awf
+    version: v0.27.27
+
 models:
   providers:
     anthropic:
@@ -172,7 +187,7 @@ pre-agent-steps:
     uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     with:
       repository: Khan/actions
-      ref: review-v1.2.1
+      ref: review-v1.2.2
       path: gh-aw-review-lib
       persist-credentials: false
 


### PR DESCRIPTION
Follow-up to #215, which did not actually fix the first-principles failure: the `models:` frontmatter block feeds gh-aw's cost-summary display (`GH_AW_INFO_MODEL_COSTS`) but never reaches the firewall api-proxy's AI-credits guard, so the proxy kept rejecting `claude-fable-5` with a 400 (verified on the next run of Khan/webapp#40678).

The real fix is `sandbox.agent.version: v0.27.27`, which runs the gh-aw-firewall release whose api-proxy bundles curated Claude 5 pricing (the same numbers #215 added for display). Verified by compiling against gh-aw v0.81.6: the agent job's awf-config `imageTag` moves from 0.27.11 to 0.27.27.

The `models:` block stays for cost-display consistency; both pieces are commented for removal once gh-aw's default firewall is >= v0.27.27. Lib-checkout ref bumped to `review-v1.2.2`, the release this ships in.

Not addressed here: the `upload_artifact` ERR_VALIDATION annotation is a gh-aw bug (the safeoutputs MCP server records the staging-relative path `out` even when the agent passes the absolute path, and the processor then validates that recorded path against `allowed-paths`); it is harmless (the staging step still uploads the files) and needs an upstream github/gh-aw issue rather than a prompt change.