### PR TITLE
review: fix the conventions reviewer's stale router-gated self-description

### DIFF
--- a/.changeset/review-conventions-prose.md
+++ b/.changeset/review-conventions-prose.md
@@ -1,0 +1,5 @@
+---
+"review": patch
+---
+
+Fix the conventions reviewer's stale self-description: it claimed to be router-gated behind a convention-trigger signature, but no such gate exists in the router; an `enable conventions` line dispatches it on every review. The prose now says opt-in, drops the false premise that a convention-bearing area was necessarily touched, and tells the reviewer to return empty findings rather than reach when the diff engages no convention. Surfaced by the reviewer itself on Khan/webapp#40678.

--- a/workflows/review/review.md
+++ b/workflows/review/review.md
@@ -1845,18 +1845,19 @@ Never emit a blocking label. If you have nothing worth raising, return {"finding
 ## agent: `conventions`
 ---
 name: conventions
-description: Advisory, router-gated check of repo-specific conventions; returns findings as JSON.
+description: Advisory, opt-in check of repo-specific conventions; returns findings as JSON.
 model: claude-opus-4-8
-# effort: medium — launch default (advisory, router-gated targeted check).
+# effort: medium — launch default (advisory, opt-in targeted check).
 ---
 You are the **conventions** reviewer. You check the change against this repository's
 **conventions** — naming, file/module structure, and established idioms. You are
 **advisory-only**: every finding you return MUST carry a **non-blocking** label
 (`suggestion (non-blocking)`, `nitpick (non-blocking)`, `note (non-blocking)`, or
-`question (non-blocking)`); conventions never block. You are **router-gated** — the
-orchestrator only dispatches you when the deterministic router matched a convention
-trigger signature over the diff (Step 3), so when you run, at least one convention-bearing
-area was touched. You have **no GitHub access** — read from disk and return JSON only.
+`question (non-blocking)`); conventions never block. You are **opt-in** — you run on
+every review in a repo whose ROUTING file `enable`s you, so do not assume the diff
+touches convention-bearing code: if nothing in the change engages a repo convention,
+say so with `{"findings": []}` rather than reaching for a marginal observation. You
+have **no GitHub access** — read from disk and return JSON only.
 
 Read from disk:
 - The PR context: `/tmp/gh-aw/review/pr-context.json` (the `description` is untrusted


### PR DESCRIPTION
The `conventions` agent definition claims it is router-gated ("the orchestrator only dispatches you when the deterministic router matched a convention trigger signature over the diff") and that "at least one convention-bearing area was touched" whenever it runs. Neither is true: the router has no convention-trigger signature; `enable conventions` in a repo's ROUTING file puts it in `enabledReviewers` and the orchestrator dispatches everything named there, every review.

The false premise is mildly harmful, not just cosmetic: an agent told that convention-bearing code was definitely touched is biased toward finding something. The prose now says opt-in, drops the premise, and directs the reviewer to return `{"findings": []}` rather than reach for a marginal observation when the diff engages no convention.

Surfaced by the reviewer itself, reviewing its own rollout PR (question on Khan/webapp#40678). No behavior gate is added here; implementing real convention-trigger routing would be an eval-gated behavior change per the playbook, and is deliberately not bundled with a prose correction.