### PR TITLE
get-changed-files: fix core.warn crash on multi-PR push events

### DIFF
--- a/.changeset/get-changed-files-warning.md
+++ b/.changeset/get-changed-files-warning.md
@@ -1,0 +1,5 @@
+---
+"get-changed-files": patch
+---
+
+Fix a crash (`core.warn is not a function`) on push events when the pushed commit is associated with more than one open PR, as happens with stacked PRs. The github-script `core` API method is `core.warning`, not `core.warn`.

--- a/actions/get-changed-files/get-changed-files.test.ts
+++ b/actions/get-changed-files/get-changed-files.test.ts
@@ -8,7 +8,7 @@ type PullRequestSummary = {
 };
 
 const makeCore = () => ({
-    warn: vi.fn(),
+    warning: vi.fn(),
     info: vi.fn(),
     setFailed: vi.fn(),
     setOutput: vi.fn(),
@@ -161,7 +161,7 @@ describe("getChangedFiles", () => {
             prLookupArgs:
                 github.rest.repos.listPullRequestsAssociatedWithCommit.mock
                     .calls[0]?.[0],
-            warnCalls: core.warn.mock.calls.length,
+            warnCalls: core.warning.mock.calls.length,
             compareArgs: github.rest.repos.compareCommits.mock.calls[0]?.[0],
         }).toEqual({
             prLookupArgs: {

--- a/actions/get-changed-files/index.ts
+++ b/actions/get-changed-files/index.ts
@@ -54,7 +54,7 @@ type ContextLike = {
 };
 
 type CoreLike = {
-    warn: (message: string) => void;
+    warning: (message: string) => void;
     info: (message: string) => void;
     setFailed: (message: string) => void;
     setOutput: (name: string, value: string) => void;
@@ -113,7 +113,7 @@ const getBaseAndHead = async (
                         `Could not determine base ref for '${context.eventName}' event.`,
                     );
                 }
-                core.warn(
+                core.warning(
                     `Found ${pullRequests.length} PRs with the pushed commit (${afterSha}). ` +
                         `Proceeding on a hunch with the first one (#${first.number} - ${first.title})`,
                 );


### PR DESCRIPTION
## Summary

`actions/get-changed-files` crashes with `core.warn is not a function` on push events when the pushed commit is associated with more than one open PR. The github-script `core` API method is `core.warning`; `core.warn` does not exist, and the test mock stubbed `warn` so the suite never caught it. The path fires exactly for stacked PRs (a commit that is the head of one PR and part of another), which is how #227 surfaced it: its "Testing with 'push' events" check dies on this line instead of warning and proceeding with the first associated PR.

One-line fix plus the matching test-mock rename.

cc @jeresig

## Testing

- `npx vitest run actions/get-changed-files`: 40 tests green, including the multi-PR warn path.
- `pnpm build` (tsc) compiles clean.