### PR TITLE
review: add allowed-domains allowlist for safe-output sanitization

### DIFF
--- a/.changeset/review-allowed-domains.md
+++ b/.changeset/review-allowed-domains.md
@@ -1,0 +1,5 @@
+---
+"review": patch
+---
+
+Expand the `allowed-domains` allowlist for the review workflow's safe outputs so links we routinely use in PRs survive gh-aw's text-sanitization. Chosen from the domains that actually appear in our PR bodies and comments (surveyed across recent Khan/frontend PRs): GitHub, khanacademy.org (incl. per-PR deploy previews), khanacademy.dev, Jira/Confluence, Slack, Claude (claude.ai + claude.com), Figma, Google Docs, and Cursor. Entries are bare hosts, which match the host and all of its subdomains.

--- a/workflows/review/review.md
+++ b/workflows/review/review.md
@@ -58,6 +58,24 @@ tools:
     toolsets: [pull_requests, repos]
 
 safe-outputs:
+  # Domains allowed to survive gh-aw's text-sanitization in this workflow's safe
+  # outputs (the inline review comments and the risks/patterns PR comment). gh-aw
+  # strips any link whose host isn't matched here, to blunt data-exfiltration via a
+  # crafted URL in untrusted PR content. Each entry matches the bare host and all of
+  # its subdomains. This list is drawn from the domains that actually appear in our PR
+  # bodies and comments (surveyed across recent Khan/frontend PRs); add a domain here
+  # when we start linking a new one.
+  allowed-domains:
+    - github.com                 # PR / issue / commit / permalink references (most common)
+    - khanacademy.org            # www, admin, and per-PR deploy previews (prod-znd-*, classroom, i18n subdomains)
+    - khanacademy.dev            # KA dev / preview environments
+    - khanacademy.atlassian.net  # Jira and Confluence
+    - khanacademy.slack.com      # Slack threads linked from PRs
+    - claude.ai                  # Claude conversation share links
+    - claude.com                 # Anthropic / Claude (current primary domain)
+    - figma.com                  # design links
+    - docs.google.com            # Google Docs
+    - cursor.com                 # Cursor (editor / agent links)
   # gh-aw's comment footer — its attribution block, including the "Add this agentic
   # workflow to your repo" install snippet (built from `source:`) — is disabled via
   # `footer: false` on the review and the risk/patterns comment below. Inline review


### PR DESCRIPTION
## What

Adds an `allowed-domains` list to the `safe-outputs:` block of the review workflow ([`workflows/review/review.md`](workflows/review/review.md)). There was no `allowed-domains` configured before, so gh-aw fell back to its defaults.

Bare hosts included (each matches the host **and all subdomains**):

| Domain | Use |
| --- | --- |
| `github.com` | PR / issue / commit / permalink references |
| `khanacademy.org` | www, admin, and per-PR deploy previews (`prod-znd-*`, classroom, i18n) |
| `khanacademy.dev` | KA dev / preview environments |
| `khanacademy.atlassian.net` | Jira and Confluence |
| `khanacademy.slack.com` | Slack threads linked from PRs |
| `claude.ai` | Claude conversation share links |
| `claude.com` | Anthropic / Claude (current primary domain) |
| `figma.com` | design links |
| `docs.google.com` | Google Docs |
| `cursor.com` | Cursor (editor / agent links) |

## Why

gh-aw strips any link from a safe output whose host isn't on the allowlist, to blunt data-exfiltration via a crafted URL in untrusted PR content. Without an explicit list, links we routinely include in reviews (deploy previews, Jira tickets, design files, etc.) get sanitized away.

## How the list was chosen

Empirically, by surveying the URLs that actually appear in recent **Khan/frontend** PR bodies and comments (~60 PRs). Domains collapsed to their registrable base and ranked by frequency; everything with real usage is included.

## Reviewer notes

- Per gh-aw's matcher (`sanitize_content_core.cjs`), a bare entry like `github.com` already matches both the bare host and every subdomain, so `*.` prefixes are unnecessary here.
- This lives in the shared `review.md` (applies across all consuming repos). The `add-reviewer` safe output and its repo-specific allowlist still live in each consumer's imported `.github/aw/review/config.md`; `allowed-domains` is a global text-sanitization setting so it belongs here.
- Includes a `patch` changeset for the `review` package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)