### PR TITLE
review: arbiter calibration harness seeded from recorded drift-run false accepts

### DIFF
--- a/.changeset/review-arbiter-calibration.md
+++ b/.changeset/review-arbiter-calibration.md
@@ -1,0 +1,5 @@
+---
+"review": patch
+---
+
+Arbiter calibration harness (the tuning memo's item 7), seeded from production evidence instead of synthetic pairs: all 10 fallback accepts recorded in drift run 29724668102, hand-labeled. 4 of the 10 were wrong (three times the cap off-by-one finding accepted for retention-dedup-window-untested; once the unreachable-quotaExceeded finding accepted for quota-cache-shared-key): same file, plausible adjacency, different defect, exactly the false-accept class the arbiter's refuse-bias prompt was supposed to prevent. `eval/arbiter-calibration.ts` replays the labeled pairs through the real arbiter seam and reports per-pair yes-rates plus false-accept/false-reject rates (~$0.02 per run at 3 samples/pair); the deterministic suite pins the set's invariants (10 pairs, 4 mismatches, none deterministically matchable, prompt-builder compatibility). Measurement only: the arbiter prompt is unchanged, since changing it is a ruler change that the calibration numbers should justify first.

--- a/workflows/review/eval/arbiter-calibration.json
+++ b/workflows/review/eval/arbiter-calibration.json
@@ -1,0 +1,227 @@
+{
+    "description": "Recorded arbiter fallback decision points from drift run 29724668102 (2026-07-20), hand-labeled. Every pair was offered to the Haiku match arbiter in production and ACCEPTED; label says whether the acceptance was correct. All pairs fail deterministic matching by construction (that is why they reached the fallback). 4 of 10 recorded accepts were wrong.",
+    "sourceRun": "29724668102",
+    "pairs": [
+        {
+            "id": "golden-retention-lifecycle-2:retention-dedup-window-untested#1",
+            "arm": "r1-baseline",
+            "label": "mismatch",
+            "note": "The accepted finding is the cap off-by-one at retention.ts:38; the spec labels the dedup window having no test. Different defect, same file.",
+            "spec": {
+                "key": "retention-dedup-window-untested",
+                "path": "src/notes/retention.ts",
+                "mechanism": [
+                    "window.*(untested|no test)|no test.*window",
+                    "DEDUP_WINDOW",
+                    "boundary"
+                ]
+            },
+            "candidate": {
+                "path": "src/notes/retention.ts",
+                "line": 38,
+                "failure_scenario": "A user accumulates 201 notes; pruneNotes queries with offset 201 (MAX_NOTES_PER_USER + 1) against a newest-first result, which returns zero stale rows, so nothing is deleted and 201 notes remain — one over the intended hard cap of 200.",
+                "model_authored_prose": "Off-by-one: offset MAX_NOTES_PER_USER + 1 lets the cap reach 201 Introduced by this change. To keep exactly 200 newest notes (indices 0-199) the query must skip 200 and return index 200+, so offset should be MAX_NOTES_PER_USER, not +1; the current +1 permanently retains one extra note per user."
+            }
+        },
+        {
+            "id": "golden-retention-fix-push:quota-cache-shared-key#1",
+            "arm": "r1-candidate",
+            "label": "mismatch",
+            "note": "The accepted finding is the unreachable quotaExceeded (< 0 after a Math.max clamp); the spec labels a shared/constant cache key leaking quota across users. Different defect, same file.",
+            "spec": {
+                "key": "quota-cache-shared-key",
+                "path": "src/notes/quota.ts",
+                "mechanism": [
+                    "shared (cache )?key|constant key|no user ?id",
+                    "quota-remaining",
+                    "another user|cross.user|leak"
+                ]
+            },
+            "candidate": {
+                "path": "src/notes/quota.ts",
+                "line": 34,
+                "failure_scenario": "A user with 800 or more non-draft notes: remainingQuota returns Math.max(0, 800-800)=0, then quotaExceeded evaluates 0 < 0 = false, so the user is never blocked and can create unlimited notes.",
+                "model_authored_prose": "quotaExceeded is now unreachable — quota is never enforced This defect is introduced by this change: line 25 clamps remainingQuota with Math.max(0, ...) so it can never be negative, while line 34 tests `< 0`, a condition that is now impossible. The two edits interact to make quotaExceeded always return false; previously (`QUOTA_LIMIT - used` unclamped, tested `<= 0`) a user at or over the limit was correctly blocked. The comment's claim that 'equality still allows a save' is the off-by-one in the wrong direction."
+            }
+        },
+        {
+            "id": "trial-dedup-composite-key:save-dedup-composite-key#1",
+            "arm": "r2-baseline",
+            "label": "match",
+            "note": "The finding describes exactly the labeled defect (dedup keyed on Body alone, dropping distinct Kinds); the mechanism regexes miss its word order.",
+            "spec": {
+                "key": "save-dedup-composite-key",
+                "path": "services/notes/save.go",
+                "mechanism": [
+                    "key(s|ed)? (the )?(dedup|seen|duplicate).{0,20} on (note\\.)?Body (alone|only)",
+                    "ignor(es?|ing) (note\\.)?Kind",
+                    "(same|identical|shared?) Body.{0,40}(different|distinct|another) [Kk]ind",
+                    "composite.{0,20}(key|identity)",
+                    "(dedup|duplicate check).{0,40}(drops?|skips?|suppress).{0,40}(summary|kind)"
+                ]
+            },
+            "candidate": {
+                "path": "services/notes/save.go",
+                "line": 32,
+                "failure_scenario": "A user already has a Kind=\"note\" with Body \"chapter three summary\"; when a Kind=\"summary\" note with the same Body is saved, it matches seen[note.Body] and is silently dropped, so the generated summary is never persisted.",
+                "model_authored_prose": "Dedup keys on Body alone, but different Kinds may legitimately share a Body store.go:14-16 documents that notes of different Kind may legitimately share a Body (\"note\" vs \"summary\"), and the dedup Query sets no Kind so `existing` spans all kinds; keying `seen` on `note.Body` alone therefore treats a distinct-Kind note with matching text as a duplicate and drops it. The same collapse happens within one batch (lines 35-40) when two notes differ only by Kind. This defect is introduced by this change. The tests only exercise same-Kind bodies, so CI would not catch it; add a case with matching Body across differing Kind."
+            }
+        },
+        {
+            "id": "golden-retention-lifecycle-2:retention-dedup-window-untested#2",
+            "arm": "r2-candidate",
+            "label": "mismatch",
+            "note": "The accepted finding is the cap off-by-one at retention.ts:38; the spec labels the dedup window having no test. Different defect, same file.",
+            "spec": {
+                "key": "retention-dedup-window-untested",
+                "path": "src/notes/retention.ts",
+                "mechanism": [
+                    "window.*(untested|no test)|no test.*window",
+                    "DEDUP_WINDOW",
+                    "boundary"
+                ]
+            },
+            "candidate": {
+                "path": "src/notes/retention.ts",
+                "line": 38,
+                "failure_scenario": "A user accumulates 201 notes; pruneNotes queries with offset MAX_NOTES_PER_USER + 1 (201) over notes sorted newest-first, so slice(201) returns an empty page, nothing is deleted, and the stored count stabilises at 201 — one over the documented hard cap of 200.",
+                "model_authored_prose": "Off-by-one: offset MAX_NOTES_PER_USER + 1 keeps 201 notes, not 200 Introduced by this change. With 0-based offset (per memDb's slice(offset)), keeping the newest 200 and deleting the rest requires offset === MAX_NOTES_PER_USER; the `+ 1` skips one extra note so the cap is effectively 201."
+            }
+        },
+        {
+            "id": "trial-dedup-composite-key:save-dedup-composite-key#2",
+            "arm": "r2-candidate",
+            "label": "match",
+            "note": "The finding describes exactly the labeled defect (dedup keyed on Body alone, dropping distinct Kinds); the mechanism regexes miss its word order.",
+            "spec": {
+                "key": "save-dedup-composite-key",
+                "path": "services/notes/save.go",
+                "mechanism": [
+                    "key(s|ed)? (the )?(dedup|seen|duplicate).{0,20} on (note\\.)?Body (alone|only)",
+                    "ignor(es?|ing) (note\\.)?Kind",
+                    "(same|identical|shared?) Body.{0,40}(different|distinct|another) [Kk]ind",
+                    "composite.{0,20}(key|identity)",
+                    "(dedup|duplicate check).{0,40}(drops?|skips?|suppress).{0,40}(summary|kind)"
+                ]
+            },
+            "candidate": {
+                "path": "services/notes/save.go",
+                "line": 32,
+                "failure_scenario": "A user already has a note {Kind:\"note\", Body:\"X\"}; SaveNotes is called with a generated {Kind:\"summary\", Body:\"X\"} — because the dedup key is Body alone, seen[\"X\"] is already true, the summary is skipped and never stored, silently losing a legitimately distinct note.",
+                "model_authored_prose": "Dedup key uses Body only, collapsing notes of different Kind store.go documents that Kind distinguishes note types and that \"notes of different kinds may share a Body\" (they are distinct entities readers select on Kind). Keying the dedup on Body alone — plus the Query on lines 23-26 omitting Kind, so `existing` spans all kinds — makes a new note of a different Kind look like a duplicate and be dropped. This defect is introduced by this change. Include Kind in both the read filter and the seen-key."
+            }
+        },
+        {
+            "id": "golden-retention-lifecycle-2:retention-dedup-window-untested#3",
+            "arm": "r3-baseline",
+            "label": "mismatch",
+            "note": "The accepted finding is the cap off-by-one at retention.ts:38; the spec labels the dedup window having no test. Different defect, same file.",
+            "spec": {
+                "key": "retention-dedup-window-untested",
+                "path": "src/notes/retention.ts",
+                "mechanism": [
+                    "window.*(untested|no test)|no test.*window",
+                    "DEDUP_WINDOW",
+                    "boundary"
+                ]
+            },
+            "candidate": {
+                "path": "src/notes/retention.ts",
+                "line": 38,
+                "failure_scenario": "A user accumulates exactly 201 notes; because offset skips MAX_NOTES_PER_USER + 1 = 201 rows before selecting stale ones, prune finds nothing and the user retains 201 notes, one above the documented hard cap of 200.",
+                "model_authored_prose": "Off-by-one: prune keeps MAX_NOTES_PER_USER + 1 notes With orderDesc newest-first, offset N keeps the N newest and deletes the rest; to enforce a cap of 200 the offset should be MAX_NOTES_PER_USER, not +1. Introduced by this change."
+            }
+        },
+        {
+            "id": "trial-amplified-default-limit:digest-amplified-default-limit#1",
+            "arm": "r3-baseline",
+            "label": "match",
+            "note": "The finding describes exactly the labeled defect (dropping Limit truncates the digest to the store default of 1).",
+            "spec": {
+                "key": "digest-amplified-default-limit",
+                "path": "services/notes/digest.go",
+                "mechanism": [
+                    "remov(e[sd]?|al|ing).{0,40}[Ll]imit",
+                    "default.{0,40}(limit.{0,12}(of )?(one|1)|(one|1|single) (row|note|result))",
+                    "(digest|summar(y|ies)).{0,60}(one|1|single) (note|row|result)",
+                    "amplif|pre-?existing|predates|already (there|present|defaulted)",
+                    "not (a )?redundan|behavio(r|ur) change|does not preserve"
+                ]
+            },
+            "candidate": {
+                "path": "services/notes/digest.go",
+                "line": 24,
+                "failure_scenario": "For any user with several summary notes, BuildDigest now returns only the single newest summary (Limit defaults to 1) instead of the intended 5, so the home digest is truncated to one line.",
+                "model_authored_prose": "Dropping Limit: digestSize makes the digest fetch 1 summary, not 5 This defect is introduced by this change. Per store.go's own doc (lines 27-31), a zero/unset Query.Limit means 1 (the store default), NOT unlimited, so Kind and Limit are orthogonal — Kind selects only summaries but does not control the row count. The PR description's premise that the Limit 'duplicated what the query narrows anyway' is incorrect; the sibling RecentPins still passes Limit: digestSize for exactly this reason, confirming the cap is load-bearing."
+            }
+        },
+        {
+            "id": "trial-dedup-composite-key:save-dedup-composite-key#3",
+            "arm": "r3-baseline",
+            "label": "match",
+            "note": "The finding describes exactly the labeled defect (dedup keyed on Body alone, dropping distinct Kinds); the mechanism regexes miss its word order.",
+            "spec": {
+                "key": "save-dedup-composite-key",
+                "path": "services/notes/save.go",
+                "mechanism": [
+                    "key(s|ed)? (the )?(dedup|seen|duplicate).{0,20} on (note\\.)?Body (alone|only)",
+                    "ignor(es?|ing) (note\\.)?Kind",
+                    "(same|identical|shared?) Body.{0,40}(different|distinct|another) [Kk]ind",
+                    "composite.{0,20}(key|identity)",
+                    "(dedup|duplicate check).{0,40}(drops?|skips?|suppress).{0,40}(summary|kind)"
+                ]
+            },
+            "candidate": {
+                "path": "services/notes/save.go",
+                "line": 32,
+                "failure_scenario": "A user already has a note {Kind:\"summary\", Body:\"chapter three\"}; they then save {Kind:\"note\", Body:\"chapter three\"}, and it is silently skipped and never stored even though it is a legitimately distinct note.",
+                "model_authored_prose": "Dedup keys on Body alone, dropping distinct notes that share a Body across Kinds store.go documents that Kind distinguishes notes and that \"notes of different kinds may share a Body\", so the identity of a note is (Kind, Body), not Body alone. The dedup query (lines 23-26) omits Kind and the seen map (lines 32/36/39) keys only on note.Body, so an incoming note whose Body collides with an existing/earlier note of a different Kind is silently discarded — user data loss with no error returned. This is introduced by this change (the file is new)."
+            }
+        },
+        {
+            "id": "incident-money-rounding:money-fp-rounding-1#1",
+            "arm": "r3-candidate",
+            "label": "match",
+            "note": "The finding describes exactly the labeled defect (integer cents converted to float dollars, rounding drift).",
+            "spec": {
+                "key": "money-fp-rounding-1",
+                "path": "src/payments/pricing.ts",
+                "mechanism": [
+                    "float(ing)?[- ]?point",
+                    "rounds? (late|once|at the end)",
+                    "drift",
+                    "unitPriceCents / 100"
+                ]
+            },
+            "candidate": {
+                "path": "src/payments/pricing.ts",
+                "line": 33,
+                "failure_scenario": "A single $1.15 item (unitPriceCents=115) with a 10% discount (rate=0.1) should total 104 cents ($1.15*0.9=$1.035 → round to $1.04), but computeCartTotal returns 103 because (115/100)*0.9*100 evaluates to 103.49999999999999 and rounds down.",
+                "model_authored_prose": "Converting integer cents to float dollars introduces a one-cent money-rounding error under discounts Introduced by this change: the old code summed exact integer cents (item.unitPriceCents * item.quantity); the new line 33 divides by 100 to work in dollars, so values like 1.15 are not exactly representable and the final Math.round on line 37 tips the wrong way at half-cent boundaries. I verified with node: correct integer math yields 104 cents but the new impl yields 103, and a sweep over rates {0.05,0.075,0.1,0.125,...} found 1674 mismatched prices under 20000 cents. Keep the subtotal in integer cents and round only after applying the discount."
+            }
+        },
+        {
+            "id": "trial-dedup-composite-key:save-dedup-composite-key#4",
+            "arm": "r3-candidate",
+            "label": "match",
+            "note": "The finding describes exactly the labeled defect (dedup keyed on Body alone, dropping distinct Kinds); the mechanism regexes miss its word order.",
+            "spec": {
+                "key": "save-dedup-composite-key",
+                "path": "services/notes/save.go",
+                "mechanism": [
+                    "key(s|ed)? (the )?(dedup|seen|duplicate).{0,20} on (note\\.)?Body (alone|only)",
+                    "ignor(es?|ing) (note\\.)?Kind",
+                    "(same|identical|shared?) Body.{0,40}(different|distinct|another) [Kk]ind",
+                    "composite.{0,20}(key|identity)",
+                    "(dedup|duplicate check).{0,40}(drops?|skips?|suppress).{0,40}(summary|kind)"
+                ]
+            },
+            "candidate": {
+                "path": "services/notes/save.go",
+                "line": 32,
+                "failure_scenario": "A user already has a generated summary {Kind:\"summary\", Body:\"Photosynthesis converts light to energy\"}; they then save a user-authored note {Kind:\"note\", Body:\"Photosynthesis converts light to energy\"}; the dedup marks it as already-seen by Body and skips it, so the distinct note is silently never stored.",
+                "model_authored_prose": "Dedup keys on Body alone, conflating notes of different Kind store.go documents that Kind distinguishes note types (\"note\" vs \"summary\") and that \"notes of different kinds may share a Body\" — yet seen[] is keyed on note.Body only, and the dedup Query at line 23 sets no Kind, so it loads existing notes of every kind. A new note whose Body matches an existing note of a different kind is dropped. This defect is introduced by this change. The key should be composite over (Kind, Body)."
+            }
+        }
+    ]
+}

--- a/workflows/review/eval/arbiter-calibration.test.ts
+++ b/workflows/review/eval/arbiter-calibration.test.ts
@@ -1,0 +1,86 @@
+import {describe, expect, it} from "vitest";
+
+import {
+    loadCalibrationSet,
+    parseCalibrationSet,
+    summarize,
+    toCandidate,
+    toSpec,
+} from "./arbiter-calibration";
+import {matchesSpec} from "./live-match";
+import {buildArbiterPrompt} from "./match-arbiter";
+
+describe("arbiter calibration set", () => {
+    const set = loadCalibrationSet();
+
+    it("carries the recorded drift-run accepts with their hand labels", () => {
+        expect(set.sourceRun).toBe("29724668102");
+        expect(set.pairs.length).toBe(10);
+        // The triage found 4 of the 10 recorded accepts were wrong: three
+        // off-by-one findings accepted for the dedup-window spec, one
+        // unreachable-quotaExceeded finding accepted for the shared-key
+        // spec. If this count changes, the labels changed; re-audit.
+        const mismatches = set.pairs.filter((p) => p.label === "mismatch");
+        expect(mismatches.length).toBe(4);
+        expect(
+            mismatches.filter((p) =>
+                p.id.startsWith(
+                    "golden-retention-lifecycle-2:retention-dedup-window-untested",
+                ),
+            ).length,
+        ).toBe(3);
+    });
+
+    it("holds the fallback invariant: no pair matches deterministically", () => {
+        // A pair the deterministic matcher already resolves never reaches
+        // the arbiter, so it cannot calibrate the arbiter. NOTE: the
+        // dedup-window pairs pin the spec AS RECORDED in the drift run
+        // (pre-altLocations fix); the calibration set is a snapshot of what
+        // the arbiter was actually asked, not a view of the live corpus.
+        for (const pair of set.pairs) {
+            expect(
+                matchesSpec(toCandidate(pair), toSpec(pair)),
+                `${pair.id} must not match deterministically`,
+            ).toBe(false);
+        }
+    });
+
+    it("feeds the real prompt builder (mechanism and finding text present)", () => {
+        const pair = set.pairs[0]!;
+        const prompt = buildArbiterPrompt(toCandidate(pair), toSpec(pair));
+        expect(prompt).toContain(pair.spec.mechanism[0]!);
+        expect(prompt).toContain(pair.candidate.failure_scenario);
+        expect(prompt).toContain("If uncertain, answer false");
+    });
+
+    it("rejects malformed sets before any model spend", () => {
+        expect(() => parseCalibrationSet({})).toThrow("missing pairs");
+        expect(() => parseCalibrationSet({pairs: [{label: "maybe"}]})).toThrow(
+            'must be "match" or "mismatch"',
+        );
+    });
+});
+
+describe("summarize", () => {
+    it("computes false-accept and false-reject rates from votes", () => {
+        const summary = summarize([
+            {id: "a", label: "mismatch", yes: 2, samples: 3},
+            {id: "b", label: "mismatch", yes: 0, samples: 3},
+            {id: "c", label: "match", yes: 3, samples: 3},
+            {id: "d", label: "match", yes: 1, samples: 3},
+        ]);
+        expect(summary.falseAcceptRate).toBeCloseTo(2 / 6);
+        expect(summary.falseRejectRate).toBeCloseTo(2 / 6);
+        expect(summary.votes).toEqual({
+            matchYes: 4,
+            matchNo: 2,
+            mismatchYes: 2,
+            mismatchNo: 4,
+        });
+    });
+
+    it("returns zero rates on an empty side rather than dividing by zero", () => {
+        expect(summarize([]).falseAcceptRate).toBe(0);
+        expect(summarize([]).falseRejectRate).toBe(0);
+    });
+});

--- a/workflows/review/eval/arbiter-calibration.test.ts
+++ b/workflows/review/eval/arbiter-calibration.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from "vitest";
 
 import {
+    distinctDecisionPoints,
     loadCalibrationSet,
     parseCalibrationSet,
     summarize,
@@ -58,6 +59,26 @@ describe("arbiter calibration set", () => {
         expect(() => parseCalibrationSet({pairs: [{label: "maybe"}]})).toThrow(
             'must be "match" or "mismatch"',
         );
+        // The guards protecting the paid live run from malformed recorded
+        // data: a spec without mechanism alternates and a candidate without
+        // its finding text.
+        expect(() =>
+            parseCalibrationSet({pairs: [{label: "match", spec: {}}]}),
+        ).toThrow("missing mechanism alternates");
+        expect(() =>
+            parseCalibrationSet({
+                pairs: [{label: "match", spec: {mechanism: []}, candidate: {}}],
+            }),
+        ).toThrow("missing finding text");
+    });
+
+    it("pools to 5 distinct decision points, not 10 independent pairs", () => {
+        // The composite-key match repeats 4x and the dedup-window mismatch
+        // 3x (same spec, same defect, re-sampled prose), so the effective N
+        // behind the pooled rates is 2 mismatch and 3 match points; the CLI
+        // prints these next to the rates so a reader weighs them correctly.
+        const distinct = distinctDecisionPoints(loadCalibrationSet().pairs);
+        expect(distinct).toEqual({match: 3, mismatch: 2});
     });
 });
 

--- a/workflows/review/eval/arbiter-calibration.ts
+++ b/workflows/review/eval/arbiter-calibration.ts
@@ -271,7 +271,9 @@ if (process.argv[1]?.endsWith("arbiter-calibration.ts")) {
         console.log(
             `\nfalse-accept rate (mismatch pairs answered yes): ${(
                 summary.falseAcceptRate * 100
-            ).toFixed(0)}% across ${distinct.mismatch} distinct decision points`,
+            ).toFixed(0)}% across ${
+                distinct.mismatch
+            } distinct decision points`,
         );
         console.log(
             `false-reject rate (match pairs answered no): ${(

--- a/workflows/review/eval/arbiter-calibration.ts
+++ b/workflows/review/eval/arbiter-calibration.ts
@@ -180,6 +180,28 @@ export type CalibrationSummary = {
     };
 };
 
+/**
+ * Distinct decision points per label. Several recorded pairs are the same
+ * arbiter decision re-sampled (same spec, same defect at the same anchor,
+ * near-identical prose from different runs): the composite-key match appears
+ * 4x and the dedup-window mismatch 3x, so the pooled rates' effective N is 5
+ * decision points, not 10 pairs, and the false-accept side moves almost
+ * entirely with one point. Reported next to the pooled rates so the
+ * percentage is weighed correctly; duplicates are extra samples of one
+ * point, not independent evidence.
+ */
+export const distinctDecisionPoints = (
+    pairs: readonly CalibrationPair[],
+): {match: number; mismatch: number} => {
+    const seen = {match: new Set<string>(), mismatch: new Set<string>()};
+    for (const pair of pairs) {
+        seen[pair.label].add(
+            `${pair.spec.key} ${pair.candidate.path} ${pair.candidate.line}`,
+        );
+    }
+    return {match: seen.match.size, mismatch: seen.mismatch.size};
+};
+
 export const summarize = (scores: PairScore[]): CalibrationSummary => {
     const votes = {matchYes: 0, matchNo: 0, mismatchYes: 0, mismatchNo: 0};
     for (const score of scores) {
@@ -207,10 +229,13 @@ export const summarize = (scores: PairScore[]): CalibrationSummary => {
 
 if (process.argv[1]?.endsWith("arbiter-calibration.ts")) {
     const samplesArg = process.argv.indexOf("--samples");
+    // `|| 3`: a trailing `--samples` with no value would otherwise produce
+    // NaN, run zero samples per pair, and print a misleading 0% false-accept
+    // rate with no model spend.
     const samples =
         samplesArg === -1
             ? 3
-            : Math.max(1, Number(process.argv[samplesArg + 1]));
+            : Math.max(1, Number(process.argv[samplesArg + 1]) || 3);
     if (!process.env["ANTHROPIC_API_KEY"]) {
         console.error(
             "ANTHROPIC_API_KEY is required for a live calibration run.",
@@ -242,15 +267,21 @@ if (process.argv[1]?.endsWith("arbiter-calibration.ts")) {
             );
         }
         const summary = summarize(scores);
+        const distinct = distinctDecisionPoints(set.pairs);
         console.log(
             `\nfalse-accept rate (mismatch pairs answered yes): ${(
                 summary.falseAcceptRate * 100
-            ).toFixed(0)}%`,
+            ).toFixed(0)}% across ${distinct.mismatch} distinct decision points`,
         );
         console.log(
             `false-reject rate (match pairs answered no): ${(
                 summary.falseRejectRate * 100
-            ).toFixed(0)}%`,
+            ).toFixed(0)}% across ${distinct.match} distinct decision points`,
+        );
+        console.log(
+            "Duplicate pairs are re-samples of one decision point (same spec, " +
+                "same defect), not independent evidence; weigh the pooled " +
+                "rates by the distinct counts.",
         );
         console.log(
             "Production behavior on this set was 100% yes (every pair is a recorded accept).",

--- a/workflows/review/eval/arbiter-calibration.ts
+++ b/workflows/review/eval/arbiter-calibration.ts
@@ -1,0 +1,260 @@
+/**
+ * Match-arbiter calibration (the tuning memo's item 7): measure the arbiter's
+ * yes-rate against hand-labeled decision points before trusting arbiter-era
+ * recall movements. The refuse bias in the arbiter prompt is a prompt, not a
+ * measurement; arbiter rescues inflate recall, the load-bearing metric.
+ *
+ * The calibration set (`eval/arbiter-calibration.json`) is not synthetic:
+ * every pair is a fallback decision the production arbiter actually made in
+ * drift run 29724668102 and answered YES to, hand-labeled afterwards. 4 of
+ * the 10 recorded accepts were wrong (three times the cap off-by-one finding
+ * accepted for the dedup-window-untested spec; once the unreachable
+ * quotaExceeded finding accepted for the shared-cache-key spec): same file,
+ * plausible adjacency, different defect. Every pair fails deterministic
+ * matching by construction (that is why it reached the fallback), which the
+ * deterministic suite pins as an invariant.
+ *
+ * Usage (live, requires ANTHROPIC_API_KEY; ~10 pairs x samples x ~$0.0006):
+ *
+ *   pnpm dlx tsx workflows/review/eval/arbiter-calibration.ts [--samples 3]
+ *
+ * Report: per-pair yes-rates and the confusion summary for the CURRENT
+ * arbiter prompt. A prompt or model-tier change motivated by these numbers
+ * is a RULER change: it re-stamps provenance and owes a noise-floor
+ * re-baseline (see eval/README.md).
+ */
+
+/* eslint-disable no-console -- CLI entry point; console IS the interface. */
+
+import {readFileSync} from "node:fs";
+
+import type {LiveDefectSpec} from "./corpus/loader";
+import {haikuMatchArbiter} from "./match-arbiter";
+import type {RunCandidate} from "./runner";
+
+export type CalibrationPair = {
+    id: string;
+    /** Which drift-run arm recorded the accept (provenance only). */
+    arm: string;
+    /** Ground truth: was accepting this pair correct? */
+    label: "match" | "mismatch";
+    note: string;
+    spec: {key: string; path: string; mechanism: string[]};
+    candidate: {
+        path: string;
+        line: number;
+        failure_scenario: string;
+        model_authored_prose: string;
+    };
+};
+
+export type CalibrationSet = {
+    description: string;
+    sourceRun: string;
+    pairs: CalibrationPair[];
+};
+
+// NOT under corpus/: the corpus loader parses every JSON there as a case.
+export const CALIBRATION_SET_PATH =
+    "workflows/review/eval/arbiter-calibration.json";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** Parse + validate the calibration set; throws a descriptive error. */
+export const parseCalibrationSet = (raw: unknown): CalibrationSet => {
+    if (!isRecord(raw) || !Array.isArray(raw["pairs"])) {
+        throw new Error("calibration set: missing pairs array");
+    }
+    const pairs = raw["pairs"].map((entry, i): CalibrationPair => {
+        const at = `pairs[${i}]`;
+        if (!isRecord(entry)) {
+            throw new Error(`${at}: not an object`);
+        }
+        const label = entry["label"];
+        if (label !== "match" && label !== "mismatch") {
+            throw new Error(`${at}.label: must be "match" or "mismatch"`);
+        }
+        const spec = entry["spec"];
+        const candidate = entry["candidate"];
+        if (!isRecord(spec) || !Array.isArray(spec["mechanism"])) {
+            throw new Error(`${at}.spec: missing mechanism alternates`);
+        }
+        if (
+            !isRecord(candidate) ||
+            typeof candidate["failure_scenario"] !== "string" ||
+            typeof candidate["model_authored_prose"] !== "string"
+        ) {
+            throw new Error(`${at}.candidate: missing finding text`);
+        }
+        return {
+            id: String(entry["id"] ?? `pair-${i}`),
+            arm: String(entry["arm"] ?? ""),
+            label,
+            note: String(entry["note"] ?? ""),
+            spec: {
+                key: String(spec["key"]),
+                path: String(spec["path"]),
+                mechanism: spec["mechanism"].map(String),
+            },
+            candidate: {
+                path: String(candidate["path"]),
+                line: Number(candidate["line"]),
+                failure_scenario: candidate["failure_scenario"],
+                model_authored_prose: candidate["model_authored_prose"],
+            },
+        };
+    });
+    return {
+        description: String(raw["description"] ?? ""),
+        sourceRun: String(raw["sourceRun"] ?? ""),
+        pairs,
+    };
+};
+
+export const loadCalibrationSet = (
+    path: string = CALIBRATION_SET_PATH,
+): CalibrationSet =>
+    parseCalibrationSet(JSON.parse(readFileSync(path, "utf8")));
+
+/** The pair as the matcher/arbiter seam consumes it. */
+export const toSpec = (pair: CalibrationPair): LiveDefectSpec => ({
+    key: pair.spec.key,
+    path: pair.spec.path,
+    mechanism: pair.spec.mechanism,
+});
+
+export const toCandidate = (pair: CalibrationPair): RunCandidate => ({
+    id: pair.id,
+    source: "calibration",
+    lens: "correctness",
+    label: "issue (blocking)",
+    blocking: true,
+    anchor: {
+        type: "line",
+        path: pair.candidate.path,
+        line: pair.candidate.line,
+        side: "RIGHT",
+    },
+    path: pair.candidate.path,
+    line: pair.candidate.line,
+    body: pair.candidate.model_authored_prose,
+    finding: {
+        schema_version: 2,
+        id: pair.id,
+        lens: "correctness",
+        anchor: {
+            type: "line",
+            path: pair.candidate.path,
+            line: pair.candidate.line,
+            side: "RIGHT",
+        },
+        severity: "blocking",
+        confidence: 0.8,
+        evidence_trace: [
+            "recorded production finding; see arbiter-calibration.json",
+        ],
+        failure_scenario: pair.candidate.failure_scenario,
+        producing_hunt: "calibration-replay",
+        model_authored_prose: pair.candidate.model_authored_prose,
+    },
+});
+
+export type PairScore = {
+    id: string;
+    label: "match" | "mismatch";
+    yes: number;
+    samples: number;
+};
+
+export type CalibrationSummary = {
+    /** Yes-votes on mismatch pairs / total mismatch votes: the rate that inflates recall. */
+    falseAcceptRate: number;
+    /** No-votes on match pairs / total match votes: the rate that leaves recall conservative. */
+    falseRejectRate: number;
+    votes: {
+        matchYes: number;
+        matchNo: number;
+        mismatchYes: number;
+        mismatchNo: number;
+    };
+};
+
+export const summarize = (scores: PairScore[]): CalibrationSummary => {
+    const votes = {matchYes: 0, matchNo: 0, mismatchYes: 0, mismatchNo: 0};
+    for (const score of scores) {
+        if (score.label === "match") {
+            votes.matchYes += score.yes;
+            votes.matchNo += score.samples - score.yes;
+        } else {
+            votes.mismatchYes += score.yes;
+            votes.mismatchNo += score.samples - score.yes;
+        }
+    }
+    const mismatchTotal = votes.mismatchYes + votes.mismatchNo;
+    const matchTotal = votes.matchYes + votes.matchNo;
+    return {
+        falseAcceptRate:
+            mismatchTotal === 0 ? 0 : votes.mismatchYes / mismatchTotal,
+        falseRejectRate: matchTotal === 0 ? 0 : votes.matchNo / matchTotal,
+        votes,
+    };
+};
+
+/* -------------------------------------------------------------------------- */
+/* CLI                                                                        */
+/* -------------------------------------------------------------------------- */
+
+if (process.argv[1]?.endsWith("arbiter-calibration.ts")) {
+    const samplesArg = process.argv.indexOf("--samples");
+    const samples =
+        samplesArg === -1
+            ? 3
+            : Math.max(1, Number(process.argv[samplesArg + 1]));
+    if (!process.env["ANTHROPIC_API_KEY"]) {
+        console.error(
+            "ANTHROPIC_API_KEY is required for a live calibration run.",
+        );
+        process.exit(1);
+    }
+    const set = loadCalibrationSet();
+    const arbiter = haikuMatchArbiter({
+        onError: (message) => console.error(`  arbiter error: ${message}`),
+    });
+    const run = async (): Promise<void> => {
+        const scores: PairScore[] = [];
+        for (const pair of set.pairs) {
+            let yes = 0;
+            for (let i = 0; i < samples; i += 1) {
+                if (await arbiter(toCandidate(pair), toSpec(pair))) {
+                    yes += 1;
+                }
+            }
+            scores.push({id: pair.id, label: pair.label, yes, samples});
+            console.log(
+                `${pair.label === "mismatch" ? "MISMATCH" : "match   "} ${
+                    pair.id
+                }: yes ${yes}/${samples}${
+                    pair.label === "mismatch" && yes > 0
+                        ? "  <-- false accept"
+                        : ""
+                }`,
+            );
+        }
+        const summary = summarize(scores);
+        console.log(
+            `\nfalse-accept rate (mismatch pairs answered yes): ${(
+                summary.falseAcceptRate * 100
+            ).toFixed(0)}%`,
+        );
+        console.log(
+            `false-reject rate (match pairs answered no): ${(
+                summary.falseRejectRate * 100
+            ).toFixed(0)}%`,
+        );
+        console.log(
+            "Production behavior on this set was 100% yes (every pair is a recorded accept).",
+        );
+    };
+    void run();
+}


### PR DESCRIPTION
## What

The tuning memo's item 7 (calibrate the match arbiter's false-positive rate), seeded from production evidence instead of synthetic pairs. The 2026-07-20 drift run (29724668102) recorded 10 fallback accepts; hand-auditing them for the stable-miss triage found **4 of the 10 were wrong**:

- 3x: the cap off-by-one finding at `retention.ts:38` accepted for `retention-dedup-window-untested`
- 1x: the unreachable-quotaExceeded finding accepted for `quota-cache-shared-key` (previously unnoticed; found while labeling this set)

All four share the same shape: same file, plausible adjacency, different defect; exactly the class the prompt's refuse bias ("not merely a nearby, related, or different issue in the same file") was supposed to prevent. Each false accept silently inflates must-catch recall, the load-bearing metric.

## Contents

- `eval/arbiter-calibration.json`: the 10 recorded decision points, verbatim finding text and spec mechanisms, hand labels (`match`/`mismatch`) with per-pair rationale. Not under `corpus/` (the loader parses every JSON there as a case).
- `eval/arbiter-calibration.ts`: replays the pairs through the real arbiter seam (`haikuMatchArbiter`) and reports per-pair yes-rates plus false-accept/false-reject rates. Live run costs ~$0.02 at the default 3 samples/pair: `ANTHROPIC_API_KEY=... pnpm dlx tsx workflows/review/eval/arbiter-calibration.ts`
- `eval/arbiter-calibration.test.ts`: deterministic invariants; 10 pairs, exactly 4 mismatches, no pair matches deterministically (else it would never reach the fallback), fixtures drive the real prompt builder.

## Deliberately not here

The arbiter prompt is unchanged. Production behavior on this set was 100% yes by construction; the harness measures whether that reproduces and at what rate, and a prompt fix (e.g. requiring the arbiter to quote which mechanism alternate the comment satisfies) should be justified by these numbers, land as a separate PR, and be treated as a ruler change (provenance re-stamp plus noise-floor re-baseline). Note the rev-4 memo decision: the calibration set is also the instrument for deciding the arbiter's model tier.

Note: after #269, the dedup-window spec matches its real finding deterministically (altLocations), which shrinks this spec's arbiter exposure but does not fix the arbiter; the false-accept class is generic, as the quota pair shows.
