### PR TITLE
terraform: store binary plans in GCS instead of committing them

### DIFF
--- a/.changeset/terraform-plan-gcs-transport.md
+++ b/.changeset/terraform-plan-gcs-transport.md
@@ -1,0 +1,12 @@
+---
+"generate-terraform-plan": major
+"apply-terraform-plan": major
+---
+
+Stop committing the Terraform binary plan file to git. A binary plan embeds a full copy of the Terraform state, including sensitive values in cleartext, and the tip-delete cleanup never removed it from git history.
+
+generate-terraform-plan now uploads the binary plan to a GCS object keyed by a slug of the terraform path plus the plan's commit SHA, and the plan PR commits only the redacted plan text plus a small pointer file (default `tfplan.commit`) recording that SHA. apply-terraform-plan reads the pointer, rebuilds the object path from its own inputs, downloads the exact plan that was reviewed, applies it, and best-effort deletes the object during cleanup.
+
+Breaking changes: both actions gain a `plan_bucket` input (required for the plan-PR/apply flow; not needed for PR-comment-only or auto_approve usage) and must be upgraded together. Consumers need a GCS bucket that the plan workflow's service account can write objects to and the apply workflow's service account can read (and ideally delete) objects from, plus a lifecycle rule to expire plans that are never applied (e.g. superseded plan PRs).
+
+Note: this only stops new leaks. Any `tfplan.binary` still committed at a repo's tip should be deleted, and histories that ever contained committed binary plans still need scrubbing and rotation of any secrets present in the embedded state.

--- a/.changeset/terraform-plan-gcs-transport.md
+++ b/.changeset/terraform-plan-gcs-transport.md
@@ -11,4 +11,6 @@ Breaking changes: both actions gain a `plan_bucket` input (required for the plan
 
 Consumer workflows must also update their trigger paths: apply workflows typically trigger on `push` with a `paths` filter on `tfplan.binary`, which is never committed anymore. Point that filter (and any `!tfplan.binary` excludes in plan workflows) at the pointer file (default `tfplan.commit`) instead, or apply will never run.
 
+Security model for the bucket: a binary plan contains the same sensitive data as the Terraform state itself, so treat the plan bucket exactly like the state bucket. Create it in the same project, enable uniform bucket-level access and public access prevention, and grant object access only to the CI service accounts (no human-facing grants). Note that project-level IAM (owners/editors, storage admins) inherits access to any bucket in the project; that audience can already read the state bucket, so the plan bucket exposes nothing new to it.
+
 Note: this only stops new leaks. Any `tfplan.binary` still committed at a repo's tip should be deleted, and histories that ever contained committed binary plans still need scrubbing and rotation of any secrets present in the embedded state.

--- a/.changeset/terraform-plan-gcs-transport.md
+++ b/.changeset/terraform-plan-gcs-transport.md
@@ -9,4 +9,6 @@ generate-terraform-plan now uploads the binary plan to a GCS object keyed by a s
 
 Breaking changes: both actions gain a `plan_bucket` input (required for the plan-PR/apply flow; not needed for PR-comment-only or auto_approve usage) and must be upgraded together. Consumers need a GCS bucket that the plan workflow's service account can write objects to and the apply workflow's service account can read (and ideally delete) objects from, plus a lifecycle rule to expire plans that are never applied (e.g. superseded plan PRs).
 
+Consumer workflows must also update their trigger paths: apply workflows typically trigger on `push` with a `paths` filter on `tfplan.binary`, which is never committed anymore. Point that filter (and any `!tfplan.binary` excludes in plan workflows) at the pointer file (default `tfplan.commit`) instead, or apply will never run.
+
 Note: this only stops new leaks. Any `tfplan.binary` still committed at a repo's tip should be deleted, and histories that ever contained committed binary plans still need scrubbing and rotation of any secrets present in the embedded state.

--- a/.changeset/terraform-plan-gcs-transport.md
+++ b/.changeset/terraform-plan-gcs-transport.md
@@ -5,7 +5,7 @@
 
 Stop committing the Terraform binary plan file to git. A binary plan embeds a full copy of the Terraform state, including sensitive values in cleartext, and the tip-delete cleanup never removed it from git history.
 
-generate-terraform-plan now uploads the binary plan to a GCS object keyed by a slug of the terraform path plus the plan's commit SHA, and the plan PR commits only the redacted plan text plus a small pointer file (default `tfplan.commit`) recording that SHA. apply-terraform-plan reads the pointer, rebuilds the object path from its own inputs, downloads the exact plan that was reviewed, applies it, and best-effort deletes the object during cleanup.
+generate-terraform-plan now uploads the binary plan to a GCS object keyed by a slug of the terraform path plus the plan's commit SHA, and the plan PR commits only the redacted plan text plus a small pointer file (default `tfplan.commit`) recording that SHA and the plan's sha256 digest. apply-terraform-plan reads the pointer, rebuilds the object path from its own inputs, downloads the plan, verifies its digest against the pointer (so the applied bytes are exactly the reviewed plan), applies it, and best-effort deletes the object once the cleanup PR has merged.
 
 Breaking changes: both actions gain a `plan_bucket` input (required for the plan-PR/apply flow; not needed for PR-comment-only or auto_approve usage) and must be upgraded together. Consumers need a GCS bucket that the plan workflow's service account can write objects to and the apply workflow's service account can read (and ideally delete) objects from, plus a lifecycle rule to expire plans that are never applied (e.g. superseded plan PRs).
 

--- a/actions/apply-terraform-plan/action.yml
+++ b/actions/apply-terraform-plan/action.yml
@@ -1,7 +1,9 @@
-# This workflow applies checked-in Terraform plans created by the `terraform-plan` workflow
+# This workflow applies Terraform plans created by the `terraform-plan` workflow
 # and can be called from any repository. It handles:
-# - Checking for plan files (unless auto_approve is enabled)
+# - Checking for the committed plan pointer/text files (unless auto_approve is enabled)
 # - Authenticating with GCP
+# - Downloading the binary plan from GCS (binary plans embed a full copy of the
+#   Terraform state, including sensitive values, so they are never committed)
 # - Applying the Terraform plan (or running a blind apply with -auto-approve)
 # - Cleaning up plan files
 # - Commenting on PRs for success/failure
@@ -20,6 +22,14 @@ inputs:
     description: "Path to the plan text file (relative to terraform_path)"
     required: false
     default: "tfplan.txt"
+  plan_pointer_path:
+    description: "Path to the committed pointer file recording the commit SHA whose uploaded binary plan should be applied (relative to terraform_path)"
+    required: false
+    default: "tfplan.commit"
+  plan_bucket:
+    description: "GCS bucket, optionally with a path prefix, that the generate-terraform-plan action uploaded the binary plan to. Must match that action's plan_bucket input. Required unless auto_approve is 'true'. The service account needs permission to read (and, for cleanup, delete) objects in this bucket."
+    required: false
+    default: ""
   gcloud_project:
     description: "Google Cloud project ID"
     required: true
@@ -68,7 +78,7 @@ runs:
         if [ "${{ inputs.auto_approve }}" == "true" ]; then
           echo "Auto-approve mode enabled, skipping plan file check"
           echo "skip_apply=false" >> "$GITHUB_OUTPUT"
-        elif [ ! -f "${{ inputs.terraform_path }}/${{ inputs.plan_file_path }}" ] || [ ! -f "${{ inputs.terraform_path }}/${{ inputs.plan_text_path }}" ]; then
+        elif [ ! -f "${{ inputs.terraform_path }}/${{ inputs.plan_pointer_path }}" ] || [ ! -f "${{ inputs.terraform_path }}/${{ inputs.plan_text_path }}" ]; then
           echo "Plan files not found, skipping apply steps"
           echo "skip_apply=true" >> "$GITHUB_OUTPUT"
         else
@@ -86,6 +96,34 @@ runs:
       with:
         workload_identity_provider: ${{ inputs.workload_identity_provider }}
         service_account: ${{ inputs.service_account }}
+
+    # generate-terraform-plan uploads the binary plan to GCS (keyed by a slug
+    # of the terraform path plus the commit SHA the plan was generated from)
+    # and commits only a pointer file, because the binary embeds a full copy
+    # of the Terraform state, including sensitive values in cleartext.
+    # Rebuilding the object path here from our own plan_bucket input, rather
+    # than trusting a URI committed to the repo, means a tampered pointer can
+    # at worst select another plan previously uploaded for this same stack.
+    - name: Download binary plan from GCS
+      if: steps.check_files.outputs.skip_apply != 'true' && inputs.auto_approve != 'true'
+      id: download
+      shell: bash
+      working-directory: ${{ inputs.terraform_path }}
+      run: |
+        if [ -z "${{ inputs.plan_bucket }}" ]; then
+          echo "The plan_bucket input is required to download the binary plan uploaded by generate-terraform-plan." >&2
+          exit 1
+        fi
+        plan_sha=$(tr -d '[:space:]' < "${{ inputs.plan_pointer_path }}")
+        if ! printf '%s' "$plan_sha" | grep -Eq '^[0-9a-f]{40}$'; then
+          echo "Pointer file ${{ inputs.plan_pointer_path }} does not contain a valid commit SHA: '$plan_sha'" >&2
+          exit 1
+        fi
+        # Slug the terraform path the same way generate-terraform-plan does.
+        slug=$(printf '%s' "${{ inputs.terraform_path }}" | tr -c 'A-Za-z0-9._-' '-' | sed -E 's/-+/-/g; s/^-//; s/-$//')
+        object="gs://${{ inputs.plan_bucket }}/${slug}/${plan_sha}/${{ inputs.plan_file_path }}"
+        gcloud storage cp "$object" "${{ inputs.plan_file_path }}"
+        echo "object=$object" >> "$GITHUB_OUTPUT"
 
     - name: Terraform Init
       if: steps.check_files.outputs.skip_apply != 'true'
@@ -106,9 +144,10 @@ runs:
         fi
       continue-on-error: true
 
-    # Once the plan is applied, we remove the checked-in plan files to clean up.
-    # This prevents stale plans from being applied and ensures that each
-    # apply job has a fresh plan generated for it.
+    # Once the plan is applied, we remove the committed pointer and plan text
+    # files to clean up, and delete the uploaded binary plan from GCS. This
+    # prevents stale plans from being applied and ensures that each apply job
+    # has a fresh plan generated for it.
     #
     # The base branch (typically `master`/`main`) is protected and rejects
     # direct pushes, so rather than committing and pushing the cleanup directly
@@ -129,7 +168,17 @@ runs:
       run: |
         # create-pull-request stages these deletions itself via add-paths; a
         # plain rm is more robust than `git rm -f` when a file is already gone.
-        rm -f "${{ inputs.terraform_path }}/${{ inputs.plan_file_path }}" "${{ inputs.terraform_path }}/${{ inputs.plan_text_path }}"
+        # The downloaded binary is untracked but removed too, so nothing later
+        # in the job can pick up an already-applied plan.
+        rm -f "${{ inputs.terraform_path }}/${{ inputs.plan_pointer_path }}" "${{ inputs.terraform_path }}/${{ inputs.plan_text_path }}" "${{ inputs.terraform_path }}/${{ inputs.plan_file_path }}"
+
+        # Best-effort delete of the uploaded binary plan; a failure (e.g. a
+        # service account without delete permission) shouldn't fail the run
+        # since the apply already succeeded. A bucket lifecycle rule should
+        # expire anything this misses, including plans that are never applied.
+        if ! gcloud storage rm "${{ steps.download.outputs.object }}"; then
+          echo "Warning: failed to delete ${{ steps.download.outputs.object }}; relying on the bucket lifecycle rule." >&2
+        fi
 
         # Scope the cleanup branch to this terraform stack. If two apply jobs
         # for different stacks run concurrently in the same repo, a shared
@@ -154,12 +203,12 @@ runs:
         body: |
           This PR was automatically generated by the `${{ github.workflow }}` workflow after the Terraform plan was applied.
 
-          It removes the checked-in plan files so that a stale plan can't be re-applied and the next run generates a fresh plan. It is merged automatically to complete the apply cycle.
+          It removes the committed plan pointer and plan text files so that a stale plan can't be re-applied and the next run generates a fresh plan. It is merged automatically to complete the apply cycle.
 
-          Plan file: `${{ inputs.terraform_path }}/${{ inputs.plan_file_path }}`
+          Plan pointer file: `${{ inputs.terraform_path }}/${{ inputs.plan_pointer_path }}`
           Plaintext plan file: `${{ inputs.terraform_path }}/${{ inputs.plan_text_path }}`
         add-paths: |
-          ${{ inputs.terraform_path }}/${{ inputs.plan_file_path }}
+          ${{ inputs.terraform_path }}/${{ inputs.plan_pointer_path }}
           ${{ inputs.terraform_path }}/${{ inputs.plan_text_path }}
 
     - name: Merge plan-file cleanup PR

--- a/actions/apply-terraform-plan/action.yml
+++ b/actions/apply-terraform-plan/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
     default: "tfplan.commit"
   plan_bucket:
-    description: "GCS bucket, optionally with a path prefix, that the generate-terraform-plan action uploaded the binary plan to. Must match that action's plan_bucket input. Required unless auto_approve is 'true'. The service account needs permission to read (and, for cleanup, delete) objects in this bucket."
+    description: "GCS bucket, optionally with a path prefix, that the generate-terraform-plan action uploaded the binary plan to. Must match that action's plan_bucket input. Required unless auto_approve is 'true'. The service account needs permission to read (and, for cleanup, delete) objects in this bucket. A binary plan contains the same sensitive data as the Terraform state, so restrict this bucket exactly like the state bucket: CI service accounts only, no human-facing grants."
     required: false
     default: ""
   gcloud_project:

--- a/actions/apply-terraform-plan/action.yml
+++ b/actions/apply-terraform-plan/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: "tfplan.txt"
   plan_pointer_path:
-    description: "Path to the committed pointer file recording the commit SHA whose uploaded binary plan should be applied (relative to terraform_path)"
+    description: "Path to the committed pointer file (relative to terraform_path) recording the commit SHA whose uploaded binary plan should be applied and that plan's sha256 digest"
     required: false
     default: "tfplan.commit"
   plan_bucket:
@@ -80,6 +80,7 @@ runs:
           echo "skip_apply=false" >> "$GITHUB_OUTPUT"
         elif [ ! -f "${{ inputs.terraform_path }}/${{ inputs.plan_pointer_path }}" ] || [ ! -f "${{ inputs.terraform_path }}/${{ inputs.plan_text_path }}" ]; then
           echo "Plan files not found, skipping apply steps"
+          echo "::warning::Plan pointer/text files not found under ${{ inputs.terraform_path }}; skipping apply. If a plan PR was just merged, check that this workflow's paths filter watches ${{ inputs.plan_pointer_path }} (not the old tfplan.binary)."
           echo "skip_apply=true" >> "$GITHUB_OUTPUT"
         else
           echo "skip_apply=false" >> "$GITHUB_OUTPUT"
@@ -114,15 +115,36 @@ runs:
           echo "The plan_bucket input is required to download the binary plan uploaded by generate-terraform-plan." >&2
           exit 1
         fi
-        plan_sha=$(tr -d '[:space:]' < "${{ inputs.plan_pointer_path }}")
+        plan_sha=$(sed -n '1p' "${{ inputs.plan_pointer_path }}" | tr -d '[:space:]')
+        plan_hash=$(sed -n '2p' "${{ inputs.plan_pointer_path }}" | tr -d '[:space:]')
         if ! printf '%s' "$plan_sha" | grep -Eq '^[0-9a-f]{40}$'; then
-          echo "Pointer file ${{ inputs.plan_pointer_path }} does not contain a valid commit SHA: '$plan_sha'" >&2
+          echo "Pointer file ${{ inputs.plan_pointer_path }} line 1 does not contain a valid commit SHA: '$plan_sha'" >&2
           exit 1
         fi
-        # Slug the terraform path the same way generate-terraform-plan does.
+        if ! printf '%s' "$plan_hash" | grep -Eq '^[0-9a-f]{64}$'; then
+          echo "Pointer file ${{ inputs.plan_pointer_path }} line 2 does not contain a valid sha256 plan digest: '$plan_hash'" >&2
+          exit 1
+        fi
+        # Slug the terraform path the same way generate-terraform-plan does;
+        # utils/terraform-plan-object-key.test.ts pins the two copies to each
+        # other. The short hash suffix keeps two terraform paths that
+        # normalize to the same slug from colliding on an object key.
         slug=$(printf '%s' "${{ inputs.terraform_path }}" | tr -c 'A-Za-z0-9._-' '-' | sed -E 's/-+/-/g; s/^-//; s/-$//')
-        object="gs://${{ inputs.plan_bucket }}/${slug}/${plan_sha}/${{ inputs.plan_file_path }}"
+        slug="${slug}-$(printf '%s' "${{ inputs.terraform_path }}" | sha256sum | cut -c1-8)"
+        # The object's filename segment is a fixed literal on both sides so
+        # the key can't depend on the two actions' independently configurable
+        # local filename inputs.
+        object="gs://${{ inputs.plan_bucket }}/${slug}/${plan_sha}/tfplan.binary"
         gcloud storage cp "$object" "${{ inputs.plan_file_path }}"
+        # Verify the downloaded bytes are exactly the plan that was reviewed;
+        # the object at this key could in principle have been overwritten
+        # since the plan PR was approved (e.g. by a re-run of the plan
+        # workflow on the same commit after state drift).
+        actual_hash=$(sha256sum "${{ inputs.plan_file_path }}" | cut -d' ' -f1)
+        if [ "$actual_hash" != "$plan_hash" ]; then
+          echo "Downloaded plan digest mismatch: the pointer records $plan_hash but the object has $actual_hash. Refusing to apply an unreviewed plan." >&2
+          exit 1
+        fi
         echo "object=$object" >> "$GITHUB_OUTPUT"
 
     - name: Terraform Init
@@ -145,9 +167,11 @@ runs:
       continue-on-error: true
 
     # Once the plan is applied, we remove the committed pointer and plan text
-    # files to clean up, and delete the uploaded binary plan from GCS. This
-    # prevents stale plans from being applied and ensures that each apply job
-    # has a fresh plan generated for it.
+    # files to clean up. This prevents stale plans from being applied and
+    # ensures that each apply job has a fresh plan generated for it. The
+    # uploaded binary plan is deleted from GCS only after the cleanup PR
+    # merges (see the final cleanup step below), so a cleanup failure never
+    # leaves the base branch pointing at a missing object.
     #
     # The base branch (typically `master`/`main`) is protected and rejects
     # direct pushes, so rather than committing and pushing the cleanup directly
@@ -171,14 +195,6 @@ runs:
         # The downloaded binary is untracked but removed too, so nothing later
         # in the job can pick up an already-applied plan.
         rm -f "${{ inputs.terraform_path }}/${{ inputs.plan_pointer_path }}" "${{ inputs.terraform_path }}/${{ inputs.plan_text_path }}" "${{ inputs.terraform_path }}/${{ inputs.plan_file_path }}"
-
-        # Best-effort delete of the uploaded binary plan; a failure (e.g. a
-        # service account without delete permission) shouldn't fail the run
-        # since the apply already succeeded. A bucket lifecycle rule should
-        # expire anything this misses, including plans that are never applied.
-        if ! gcloud storage rm "${{ steps.download.outputs.object }}"; then
-          echo "Warning: failed to delete ${{ steps.download.outputs.object }}; relying on the bucket lifecycle rule." >&2
-        fi
 
         # Scope the cleanup branch to this terraform stack. If two apply jobs
         # for different stacks run concurrently in the same repo, a shared
@@ -231,6 +247,24 @@ runs:
         done
         echo "Failed to merge cleanup PR #$PR_NUMBER after several attempts" >&2
         exit 1
+
+    # Delete the uploaded binary plan only after the cleanup PR has merged.
+    # If the object were deleted first and the cleanup PR then failed to
+    # create or merge, the base branch would keep a pointer to a missing
+    # object and every re-run of this workflow would hard-fail at download
+    # until a new plan regenerates. (This step is skipped automatically if
+    # any earlier step failed.)
+    - name: Delete uploaded plan from GCS
+      if: steps.apply.outcome == 'success' && inputs.cleanup_plan_files == 'true' && inputs.auto_approve != 'true' && steps.download.outputs.object != ''
+      shell: bash
+      run: |
+        # Best-effort: a failure (e.g. a service account without delete
+        # permission) shouldn't fail the run since the apply already
+        # succeeded and the pointer is gone. A bucket lifecycle rule should
+        # expire anything this misses, including plans that are never applied.
+        if ! gcloud storage rm "${{ steps.download.outputs.object }}"; then
+          echo "Warning: failed to delete ${{ steps.download.outputs.object }}; relying on the bucket lifecycle rule." >&2
+        fi
 
     - name: Find merged PR
       if: steps.apply.outcome == 'success' || steps.apply.outcome == 'failure'

--- a/actions/generate-terraform-plan/action.yml
+++ b/actions/generate-terraform-plan/action.yml
@@ -31,7 +31,7 @@ inputs:
     required: false
     default: "tfplan.commit"
   plan_bucket:
-    description: "GCS bucket, optionally with a path prefix (e.g. 'my-bucket/terraform-plans'), where the binary plan is uploaded. Required when enable_pr_creation is 'true'. Must match the apply-terraform-plan action's plan_bucket input. The service account needs permission to create objects in this bucket."
+    description: "GCS bucket, optionally with a path prefix (e.g. 'my-bucket/terraform-plans'), where the binary plan is uploaded. Required when enable_pr_creation is 'true'. Must match the apply-terraform-plan action's plan_bucket input. The service account needs permission to create objects in this bucket. A binary plan contains the same sensitive data as the Terraform state, so restrict this bucket exactly like the state bucket: CI service accounts only, no human-facing grants."
     required: false
     default: ""
   workload_identity_provider:

--- a/actions/generate-terraform-plan/action.yml
+++ b/actions/generate-terraform-plan/action.yml
@@ -27,7 +27,7 @@ inputs:
     required: false
     default: "tfplan.txt"
   plan_file_pointer:
-    description: "Filename for the committed pointer file that records the commit SHA whose uploaded binary plan should be applied"
+    description: "Filename for the committed pointer file that records the commit SHA whose uploaded binary plan should be applied and that plan's sha256 digest"
     required: false
     default: "tfplan.commit"
   plan_bucket:
@@ -165,19 +165,29 @@ runs:
           echo "The plan_bucket input is required when enable_pr_creation is 'true': the binary plan is uploaded to GCS instead of being committed." >&2
           exit 1
         fi
-        # Slug the terraform path the same way apply-terraform-plan does so
-        # concurrent stacks in one repo can't collide on an object path.
+        # Slug the terraform path the same way apply-terraform-plan does, so
+        # concurrent stacks in one repo can't collide on an object path;
+        # utils/terraform-plan-object-key.test.ts pins the two copies to each
+        # other. The short hash suffix keeps two terraform paths that
+        # normalize to the same slug from colliding.
         slug=$(printf '%s' "${{ inputs.terraform_path }}" | tr -c 'A-Za-z0-9._-' '-' | sed -E 's/-+/-/g; s/^-//; s/-$//')
-        object="gs://${{ inputs.plan_bucket }}/${slug}/${{ github.sha }}/${{ inputs.plan_file_binary }}"
+        slug="${slug}-$(printf '%s' "${{ inputs.terraform_path }}" | sha256sum | cut -c1-8)"
+        # The object's filename segment is a fixed literal on both sides so
+        # the key can't depend on the two actions' independently configurable
+        # local filename inputs.
+        object="gs://${{ inputs.plan_bucket }}/${slug}/${{ github.sha }}/tfplan.binary"
+        plan_hash=$(sha256sum "${{ inputs.plan_file_binary }}" | cut -d' ' -f1)
         gcloud storage cp "${{ inputs.plan_file_binary }}" "$object"
         rm -f "${{ inputs.plan_file_binary }}"
-        # The pointer deliberately holds only the commit SHA, not a full
-        # gs:// URI: apply-terraform-plan reconstructs the object path from
-        # its own workflow-configured inputs, so a tampered pointer can at
-        # worst select another plan previously uploaded for this same stack.
-        printf '%s\n' "${{ github.sha }}" > "${{ inputs.plan_file_pointer }}"
+        # The pointer records the commit SHA the plan was generated from and
+        # the plan's sha256, which apply-terraform-plan verifies after
+        # download so the applied bytes are exactly the reviewed plan. It
+        # deliberately holds no gs:// URI: apply reconstructs the object path
+        # from its own workflow-configured inputs, so a tampered pointer
+        # cannot point apply at an arbitrary object.
+        printf '%s\n%s\n' "${{ github.sha }}" "$plan_hash" > "${{ inputs.plan_file_pointer }}"
         echo "object=$object" >> "$GITHUB_OUTPUT"
-        echo "Uploaded binary plan to $object"
+        echo "Uploaded binary plan to $object (sha256 $plan_hash)"
 
     - name: Get Last Deployed Commit
       if: steps.plan.outputs.has_changes == 'true' && github.ref_name == inputs.pr_creation_branch && inputs.enable_pr_creation == 'true'

--- a/actions/generate-terraform-plan/action.yml
+++ b/actions/generate-terraform-plan/action.yml
@@ -3,7 +3,10 @@
 # - Checking for plan files
 # - Authenticating with GCP
 # - Generating a Terraform plan
-# - Handling PR creation/comments
+# - Uploading the binary plan to GCS (binary plans embed a full copy of the
+#   Terraform state, including sensitive values, so they are never committed)
+# - Handling PR creation/comments (the PR contains only the redacted plan
+#   text and a pointer file recording which uploaded plan to apply)
 # - Commenting on PRs for success/failure
 # All environment variables starting with TF_VAR_ will be automatically picked up by Terraform
 # Example: TF_VAR_project_id, TF_VAR_region, etc.
@@ -23,6 +26,14 @@ inputs:
     description: "Filename for the text plan file"
     required: false
     default: "tfplan.txt"
+  plan_file_pointer:
+    description: "Filename for the committed pointer file that records the commit SHA whose uploaded binary plan should be applied"
+    required: false
+    default: "tfplan.commit"
+  plan_bucket:
+    description: "GCS bucket, optionally with a path prefix (e.g. 'my-bucket/terraform-plans'), where the binary plan is uploaded. Required when enable_pr_creation is 'true'. Must match the apply-terraform-plan action's plan_bucket input. The service account needs permission to create objects in this bucket."
+    required: false
+    default: ""
   workload_identity_provider:
     description: "Workload Identity Provider for Google Cloud authentication"
     required: true
@@ -132,6 +143,42 @@ runs:
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
         fi
 
+    # A binary plan file embeds a full copy of the Terraform state, including
+    # sensitive values in cleartext, regardless of what the plan changes.
+    # Committing it would put that state into git history permanently, so we
+    # upload it to an access-controlled GCS bucket instead and commit only a
+    # small pointer file recording the commit SHA the plan was generated from.
+    # The apply-terraform-plan action rebuilds the object path from its own
+    # plan_bucket input plus that SHA and downloads the exact plan that was
+    # reviewed. Plans that are never applied (e.g. superseded plan PRs) leave
+    # objects behind; configure a lifecycle rule on the bucket to expire them.
+    #
+    # The gcloud CLI is preinstalled on GitHub-hosted runners and picks up the
+    # credentials exported by the auth step above.
+    - name: Upload binary plan to GCS
+      if: inputs.enable_pr_creation == 'true' && github.ref_name == inputs.pr_creation_branch && steps.plan.outputs.has_changes == 'true'
+      id: upload
+      shell: bash
+      working-directory: ${{ inputs.terraform_path }}
+      run: |
+        if [ -z "${{ inputs.plan_bucket }}" ]; then
+          echo "The plan_bucket input is required when enable_pr_creation is 'true': the binary plan is uploaded to GCS instead of being committed." >&2
+          exit 1
+        fi
+        # Slug the terraform path the same way apply-terraform-plan does so
+        # concurrent stacks in one repo can't collide on an object path.
+        slug=$(printf '%s' "${{ inputs.terraform_path }}" | tr -c 'A-Za-z0-9._-' '-' | sed -E 's/-+/-/g; s/^-//; s/-$//')
+        object="gs://${{ inputs.plan_bucket }}/${slug}/${{ github.sha }}/${{ inputs.plan_file_binary }}"
+        gcloud storage cp "${{ inputs.plan_file_binary }}" "$object"
+        rm -f "${{ inputs.plan_file_binary }}"
+        # The pointer deliberately holds only the commit SHA, not a full
+        # gs:// URI: apply-terraform-plan reconstructs the object path from
+        # its own workflow-configured inputs, so a tampered pointer can at
+        # worst select another plan previously uploaded for this same stack.
+        printf '%s\n' "${{ github.sha }}" > "${{ inputs.plan_file_pointer }}"
+        echo "object=$object" >> "$GITHUB_OUTPUT"
+        echo "Uploaded binary plan to $object"
+
     - name: Get Last Deployed Commit
       if: steps.plan.outputs.has_changes == 'true' && github.ref_name == inputs.pr_creation_branch && inputs.enable_pr_creation == 'true'
       id: last_deployed
@@ -198,8 +245,10 @@ runs:
 
           Note, this plan reflects the current state of the `${{ inputs.pr_creation_branch }}` branch and may include changes from multiple contributors.
 
-          Plan file: `${{ inputs.terraform_path }}/${{ inputs.plan_file_binary }}`
           Plaintext plan file: `${{ inputs.terraform_path }}/${{ inputs.plan_file_text }}`
+          Binary plan: `${{ steps.upload.outputs.object }}`
+
+          The binary plan is stored in GCS rather than committed because it embeds a full copy of the Terraform state, including sensitive values. The committed pointer file `${{ inputs.terraform_path }}/${{ inputs.plan_file_pointer }}` records which uploaded plan the apply workflow will download.
 
           ## Changes Since Last Deployment
           You can view all changes that have not yet been deployed [here](https://github.com/${{ github.repository }}/compare/${{ steps.last_deployed.outputs.last_deployed }}...${{ github.sha }}).
@@ -217,7 +266,7 @@ runs:
 
           ${{ inputs.pr_extra_text }}
         add-paths: |
-          ${{ inputs.terraform_path }}/${{ inputs.plan_file_binary }}
+          ${{ inputs.terraform_path }}/${{ inputs.plan_file_pointer }}
           ${{ inputs.terraform_path }}/${{ inputs.plan_file_text }}
         base: ${{ inputs.pr_creation_branch }}
         reviewers: ${{ steps.reviewer.outputs.reviewer }}

--- a/utils/terraform-plan-object-key.test.ts
+++ b/utils/terraform-plan-object-key.test.ts
@@ -1,0 +1,99 @@
+import {describe, it, expect} from "vitest";
+import * as realFs from "node:fs";
+import path from "node:path";
+import {execSync} from "node:child_process";
+
+// generate-terraform-plan uploads the binary plan to a GCS object whose path
+// apply-terraform-plan later reconstructs from its own inputs. The slug logic
+// is necessarily duplicated inline in both composite actions: published tags
+// contain a single action's directory (see utils/publish.ts), so the two
+// actions cannot share a helper file. These tests pin the copies to each
+// other; if either drifts, apply reconstructs a different object path than
+// generate wrote and every apply 404s.
+
+const readAction = (name: string): string =>
+    realFs.readFileSync(
+        path.join(__dirname, "..", "actions", name, "action.yml"),
+        "utf-8",
+    );
+
+const generateYml = readAction("generate-terraform-plan");
+const applyYml = readAction("apply-terraform-plan");
+
+const extractLines = (source: string, pattern: RegExp): string[] =>
+    source
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => pattern.test(line));
+
+const SLUG_PIPELINE = /^slug=\$\(printf '%s' .+\| tr -c /;
+const HASH_SUFFIX = /^slug="\$\{slug\}-\$\(printf '%s' .+sha256sum/;
+
+// Run one of the extracted slug pipelines against a sample input by swapping
+// the GitHub expression for an environment variable. This executes the exact
+// bytes from the action files, not a retyped copy.
+const runSlugPipeline = (pipelineLine: string, input: string): string => {
+    const command = pipelineLine
+        .replace(/^slug=\$\((.*)\)$/, "$1")
+        .replace('"${{ inputs.terraform_path }}"', '"$TF_PATH"');
+    return execSync(command, {
+        env: {...process.env, TF_PATH: input},
+        encoding: "utf-8",
+    });
+};
+
+describe("terraform plan GCS object key", () => {
+    it("uses byte-identical slug pipelines everywhere", () => {
+        const generateSlugs = extractLines(generateYml, SLUG_PIPELINE);
+        const applySlugs = extractLines(applyYml, SLUG_PIPELINE);
+
+        // One in generate's upload step; two in apply (download step and the
+        // pre-existing cleanup-branch naming, which uses the same pipeline).
+        expect(generateSlugs).toHaveLength(1);
+        expect(applySlugs).toHaveLength(2);
+
+        for (const line of [...generateSlugs, ...applySlugs]) {
+            expect(line).toBe(generateSlugs[0]);
+        }
+    });
+
+    it("uses byte-identical collision-hash suffixes in both actions", () => {
+        const generateHash = extractLines(generateYml, HASH_SUFFIX);
+        const applyHash = extractLines(applyYml, HASH_SUFFIX);
+
+        expect(generateHash).toHaveLength(1);
+        expect(applyHash).toHaveLength(1);
+        expect(applyHash[0]).toBe(generateHash[0]);
+    });
+
+    it("uses a fixed object filename segment on both sides", () => {
+        // The filename segment must not depend on the two actions'
+        // independently configurable local filename inputs
+        // (plan_file_binary vs plan_file_path).
+        const generateObject = extractLines(generateYml, /^object="gs:\/\//);
+        const applyObject = extractLines(applyYml, /^object="gs:\/\//);
+
+        expect(generateObject).toHaveLength(1);
+        expect(applyObject).toHaveLength(1);
+        expect(generateObject[0]).toMatch(/\/tfplan\.binary"$/);
+        expect(applyObject[0]).toMatch(/\/tfplan\.binary"$/);
+    });
+
+    it.each([
+        ["terraform/culture-cron", "terraform-culture-cron"],
+        [
+            "github-actions-runner/terraform/runner",
+            "github-actions-runner-terraform-runner",
+        ],
+        ["a//b", "a-b"],
+        ["/leading/and/trailing/", "leading-and-trailing"],
+        ["with_underscore.dot", "with_underscore.dot"],
+        // These two normalize identically; the sha256 suffix appended after
+        // this pipeline is what keeps their object keys distinct.
+        ["terraform/foo", "terraform-foo"],
+        ["terraform-foo", "terraform-foo"],
+    ])("slugs %s to %s", (input, expected) => {
+        const [pipeline] = extractLines(generateYml, SLUG_PIPELINE);
+        expect(runSlugPipeline(pipeline, input)).toBe(expected);
+    });
+});

--- a/utils/terraform-plan-object-key.test.ts
+++ b/utils/terraform-plan-object-key.test.ts
@@ -94,6 +94,9 @@ describe("terraform plan GCS object key", () => {
         ["terraform-foo", "terraform-foo"],
     ])("slugs %s to %s", (input, expected) => {
         const [pipeline] = extractLines(generateYml, SLUG_PIPELINE);
+        if (!pipeline) {
+            throw new Error("No slug pipeline found in generate action");
+        }
         expect(runSlugPipeline(pipeline, input)).toBe(expected);
     });
 });


### PR DESCRIPTION
## Summary

A Terraform binary plan file is a zip that embeds a full copy of the Terraform state, including sensitive attribute values in cleartext, regardless of what the plan actually changes. `generate-terraform-plan` has been committing that file to consumer repos in the plan PR, and the `apply-terraform-plan` cleanup only deletes it from the tip; every plan ever merged is still in git history. This PR stops committing the binary entirely and moves it to an access-controlled GCS object instead, while keeping the review-then-apply-on-merge flow intact.

## How it works now

- `generate-terraform-plan` uploads the binary to `gs://<plan_bucket>/<slug of terraform_path>/<commit SHA>/tfplan.binary` and deletes the local copy. The plan PR commits only the redacted `tfplan.txt` (unchanged, still the human review content) plus a new pointer file (default `tfplan.commit`) containing the commit SHA the plan was generated from.
- `apply-terraform-plan` reads the SHA from the pointer, validates it, rebuilds the object path from its own `plan_bucket` input, downloads the exact plan that was reviewed, and applies it as before. The cleanup PR removes the pointer and text files, and the action best-effort deletes the GCS object.
- The pointer holds only a SHA, never a full `gs://` URI. Apply reconstructs the path from workflow-configured inputs, so a tampered pointer can at worst select another plan previously uploaded for the same stack; it cannot point apply at an arbitrary object. This is strictly better than before, when a tampered PR could swap the entire binary.
- The object path includes a slug of `terraform_path` (same slug logic as the per-stack cleanup branch) so multiple stacks in one repo cannot collide.
- The PR-comment path (plans on feature-branch PRs) and `auto_approve` mode are unchanged and do not need a bucket.
- No new auth machinery: both actions already authenticate via `google-github-actions/auth` with WIF, which configures the preinstalled `gcloud` CLI automatically.

## Breaking changes (major bump for both actions)

- New `plan_bucket` input on both actions, required for the plan-PR/apply flow. Both actions must be upgraded together.
- Consumers need a GCS bucket the plan service account can write objects to and the apply service account can read (and ideally delete) objects from, plus a lifecycle rule to expire plans that are never applied (e.g. superseded plan PRs).
- In-flight plan PRs generated by the old version will be skipped by the new apply action (missing pointer file); a fresh plan PR gets generated on the next run. Any `tfplan.binary` still committed at a consumer repo's tip should be deleted manually.

## Follow-up (not in this PR)

This only stops new leaks. Consumer repos that ever merged a plan PR have binary plans, and therefore cleartext state, in git history today; those histories need scrubbing (git filter-repo/BFG) and rotation of any secrets present in the embedded state.
