### PR TITLE
review eval: report a per-spec blocking rate (severity stability instrumentation)

### DIFF
--- a/.changeset/review-eval-severity-stability.md
+++ b/.changeset/review-eval-severity-stability.md
@@ -1,0 +1,11 @@
+---
+"review": patch
+---
+
+Eval instrumentation only: report a per-spec **blocking rate** alongside the per-spec catch rate, so severity is observable per defect instead of only per case. Spec matching scores detection — a `mustCatchSpec` is satisfied by anchor agreement plus a mechanism regex, and none of the 41 must-catch specs in the corpus constrains the label (the only two `blockingOnly` flags sit on `mustNotFlagSpecs` traps, where the field means the opposite thing) — so a run can score 100% must-catch recall while labelling every seeded defect a nitpick. `verdictAgreement` cannot substitute, being a whole-case check that any other blocking finding compensates for: on Khan/webapp#41194 `TopKey`'s zero-floor bug was labelled blocking and held the verdict at REQUEST_CHANGES while a claim-validator-*confirmed* nil-map panic posted as `suggestion (non-blocking)`.
+
+Four field-plumbing changes, no new model spend and no new dispatches: `SpecMatch` carries the matching candidate's `blocking` flag (copied from `RunCandidate.blocking`, which is code-computed from `severity`, never model-authored); `SampleRun` parses those into a sparse `caughtSpecBlocking` map; `SpecAggregate` gains a `blocking` rate beside `caught`, rendered as a `<case>:<spec> (blocking)` row in the existing per-spec table; and `sampleRates` gains `blocking rate (caught specs)` so it picks up a noise-floor band. The weekly drift watch already samples 3 repeats x 2 identical arms, so it starts producing six severity samples per defect at its existing $220 budget, unchanged.
+
+**Report-only. Nothing gates on the new metric.** On an identical-arm pool a blocking rate strictly between 0 and 1 is unstable by construction — same prompt, same input, split vote — so those rows print `severity split` and no threshold tuning is intended. An unrecorded label (report artifacts predating this change) is excluded from the denominator rather than counted non-blocking, and the row and the band are omitted entirely rather than printed as a fabricated 0%.
+
+No change to the shipped review workflow: `review.md`, the lock, the finding schema, and `BLOCKING_LABELS` are all untouched.

--- a/workflows/review/eval/README.md
+++ b/workflows/review/eval/README.md
@@ -138,6 +138,30 @@ claiming a band.
   arms both sit inside a band is wobble. Detecting a 20-point recall change
   needs ~60 spec-samples per arm; 10 points needs ~140 (two-proportion, 80%
   power). Repeats are the cheap axis: no authoring, no review.
+- **Blocking rate (severity stability, report-only):** every per-spec row is
+  followed by a `<case>:<spec> (blocking)` row — of the repeats that CAUGHT
+  that spec, how many labelled it blocking — and the pooled bands carry
+  `blocking rate (caught specs)`. It exists because **matching scores
+  detection, not severity**: a spec is satisfied by anchor agreement plus a
+  mechanism regex, and no `mustCatchSpecs` entry in the corpus constrains the
+  label (the only two `blockingOnly` flags are on `mustNotFlagSpecs` traps,
+  where the field means the opposite thing). So a run can score 100%
+  must-catch recall while calling every seeded defect a nitpick. Verdict
+  agreement does not cover the gap either, being per case: any *other*
+  blocking finding compensates. Khan/webapp#41194 is the worked example —
+  `TopKey`'s zero-floor bug was labelled blocking and held the verdict at
+  REQUEST_CHANGES while a claim-validator-**confirmed** nil-map panic posted
+  as `suggestion (non-blocking)`.
+  On an **identical-arm** pool (the weekly drift run, or any `--force-arms`
+  wobble control) a blocking rate strictly between 0 and 1 is **unstable by
+  construction**: same prompt, same input, split vote, which is the definition
+  of noise rather than a number to compare against a threshold. Those rows
+  print `severity split`. **No threshold tuning is intended and nothing gates
+  on this metric** — it is instrumentation, and what to do about a split is a
+  separate, deliberately deferred decision (asserting which defect classes
+  must block is a ground-truth call for the repo owner). Rows are omitted, not
+  zeroed, for report artifacts predating the instrumentation: an unrecorded
+  label is no evidence, never "non-blocking".
 - **Miss classes:** a true miss is a recall problem; found-but-dropped
   (provenance/scope/validation buckets) is an anchoring or gate-calibration
   problem. They route to different fixes; never collapse them. The

--- a/workflows/review/eval/aggregate-severity.ts
+++ b/workflows/review/eval/aggregate-severity.ts
@@ -1,0 +1,105 @@
+/**
+ * The per-spec **severity-stability** metric: of the repeats that caught a
+ * given spec, how many labelled it blocking.
+ *
+ * Split out of `aggregate.ts` (which sits at its `max-lines` ceiling) as the
+ * self-contained half of the metric: the vocabulary, the two predicates, and
+ * the reader-facing prose. The counters themselves are two lines interleaved
+ * in `aggregateArm`'s accumulation loop and stay there.
+ *
+ * ## Why the metric exists
+ *
+ * Spec matching scores **detection, not severity**. `live-match.ts` satisfies
+ * a `mustCatchSpec` on anchor agreement plus a mechanism-regex hit; the
+ * label plays no part unless the spec sets `blockingOnly`, and no
+ * `mustCatchSpecs` entry in the corpus does — the only two that set it are
+ * `mustNotFlagSpecs` traps, where the field means the opposite thing (don't
+ * score a non-blocking mention as a false flag). So a run that finds every
+ * seeded defect and labels every one of them `nitpick (non-blocking)` scores
+ * 100% must-catch recall.
+ *
+ * `verdictAgreement` does not close the gap. It is a whole-case check, so any
+ * *other* blocking finding on the case compensates for a defect that shipped
+ * non-blocking. Khan/webapp#41194 is the worked example: `TopKey`'s
+ * zero-floor bug was labelled blocking and held the verdict at
+ * REQUEST_CHANGES while a claim-validator-**confirmed** nil-map panic posted
+ * as `suggestion (non-blocking)`. Verdict agreement green; one confirmed
+ * panic out the door as a suggestion.
+ *
+ * ## What it does not do
+ *
+ * It does not say which label was *right*. That is a ground-truth question,
+ * and answering it means asserting per-spec expected severity — a separate,
+ * deliberately deferred decision. This metric only reports what the reviewer
+ * did, and (on an identical-arm pool) whether it did the same thing twice.
+ *
+ * Report-only throughout: nothing here gates a run.
+ */
+
+/** The noise-floor band key, shared by the sampler and its tests. */
+export const SEVERITY_BAND_METRIC = "blocking rate (caught specs)";
+
+/** The `Miss classes` cell marking a spec whose label was not stable. */
+export const SEVERITY_SPLIT_NOTE = "severity split";
+
+/**
+ * The recorded label for one caught spec: `true`/`false` when the report
+ * carried one, `undefined` when it did not — **no severity evidence, never
+ * "non-blocking"**. Artifacts predating `SpecMatch.blocking` carry none, and
+ * reading those as non-blocking would invent evidence and drag every rate
+ * toward zero.
+ *
+ * Takes the map rather than the run, and tolerates it being absent entirely:
+ * `workflows/` sits outside the root tsconfig's `include`, so a hand-built
+ * `SampleRun` missing the field is a runtime crash rather than a compile
+ * error, and absent already has a defined meaning here.
+ */
+export const caughtBlocking = (
+    caughtSpecBlocking: Record<string, boolean> | undefined,
+    specKey: string,
+): boolean | undefined => caughtSpecBlocking?.[specKey];
+
+/**
+ * Whether a blocking rate is a **split vote**: the same defect, found by the
+ * same prompt on the same input, labelled blocking on some repeats and not on
+ * others.
+ *
+ * Strictly between 0 and 1 is the whole test. With the prompt and the input
+ * held fixed there is no threshold to tune, because a split IS the
+ * instability — it is definitionally noise, not a number to compare against a
+ * bar. `0/n` and `n/n` are consistent (whether or not the consistent answer is
+ * the correct one, which this metric does not ask).
+ *
+ * Only meaningful on an identical-arm pool. Across genuinely different arms a
+ * split is a prompt delta, which is what an A/B is for.
+ */
+export const isSeveritySplit = (
+    numerator: number,
+    denominator: number,
+): boolean => denominator > 0 && numerator > 0 && numerator < denominator;
+
+/**
+ * The prose above the per-case table explaining the `(blocking)` rows. Kept
+ * with the metric so the explanation and the numbers cannot drift apart.
+ */
+export const severityTableNote = (identicalArms: boolean): string[] => [
+    "A `(blocking)` row reports, of the repeats that CAUGHT that spec, how " +
+        "many labelled it blocking. Catching a spec says nothing about " +
+        "severity: a spec is satisfied by anchor plus mechanism, and no " +
+        "`mustCatchSpecs` entry constrains the label, so a run can score 100% " +
+        "must-catch recall while calling every seeded defect a nitpick. " +
+        "Verdict agreement does not cover it either, being per-case: any " +
+        "other blocking finding compensates.",
+    "",
+    ...(identicalArms
+        ? [
+              "The arms here are identical, so a `(blocking)` rate strictly " +
+                  "between 0 and 1 is **unstable by construction** — same " +
+                  "prompt, same input, split vote, which is the definition of " +
+                  `noise rather than a number to tune against. Marked \`${SEVERITY_SPLIT_NOTE}\`. ` +
+                  "No threshold tuning is intended and nothing gates on these " +
+                  "rows.",
+              "",
+          ]
+        : []),
+];

--- a/workflows/review/eval/aggregate.test.ts
+++ b/workflows/review/eval/aggregate.test.ts
@@ -23,6 +23,12 @@ const rawRun = (
         verdict?: string;
         expected?: string;
         caught?: string[];
+        /**
+         * Spec key -> the label the catch carried. A key absent from this map
+         * serializes a `caught` entry with no `blocking` field, i.e. an
+         * artifact predating the severity instrumentation.
+         */
+        blocking?: Record<string, boolean>;
         missedDetail?: {specKey: string; droppedBy?: string}[];
         unmatched?: string[];
         posted?: number;
@@ -39,6 +45,9 @@ const rawRun = (
             specKey,
             findingId: `${caseId}:f`,
             via: "deterministic",
+            ...(over.blocking?.[specKey] !== undefined
+                ? {blocking: over.blocking[specKey]}
+                : {}),
         })),
         missed: (over.missedDetail ?? []).map((d) => d.specKey),
         missedDetail: over.missedDetail ?? [],
@@ -134,6 +143,35 @@ describe("extractSamples", () => {
         expect(sample.candidate.runs[0]?.unmatchedPosted).toBe(1);
         expect(sample.candidate.runs[0]?.posted).toBe(2);
         expect(sample.baseline.usd).toBe(1.5);
+    });
+
+    it("carries recorded catch labels and omits unrecorded ones", () => {
+        // Version tolerance, and the reason it matters: a report predating
+        // SpecMatch.blocking carries no label, and reading that as
+        // "non-blocking" would invent severity evidence a legacy artifact
+        // never had.
+        const raw = rawReport({
+            baselineRuns: [
+                rawRun("case-1", {
+                    caught: ["spec-1", "spec-2"],
+                    blocking: {"spec-1": true},
+                    posted: 2,
+                }),
+            ],
+            candidateRuns: [
+                rawRun("case-1", {
+                    caught: ["spec-1"],
+                    blocking: {"spec-1": false},
+                }),
+            ],
+        });
+        const sample = extractSamples("r1", raw)[0]!;
+        expect(sample.baseline.runs[0]?.caughtSpecBlocking).toEqual({
+            "spec-1": true,
+        });
+        expect(sample.candidate.runs[0]?.caughtSpecBlocking).toEqual({
+            "spec-1": false,
+        });
     });
 
     it("flattens a --repeats artifact into one sample per repeat", () => {
@@ -240,6 +278,7 @@ describe("aggregateSamples", () => {
         expectedVerdict: "REQUEST_CHANGES",
         verdict: "REQUEST_CHANGES",
         caughtSpecKeys: [],
+        caughtSpecBlocking: {},
         missedSpecs: [],
         unmatchedPosted: 0,
         posted: 0,
@@ -325,6 +364,45 @@ describe("aggregateSamples", () => {
         expect(report.arms.baseline.pooled.usd).toBe(3);
     });
 
+    it("rates severity over labelled catches only, never over all catches", () => {
+        // Six repeats of one spec, always caught, blocking on four of them:
+        // recall 6/6 says the reviewer never misses it, blocking 4/6 says it
+        // cannot decide whether it matters. Recall alone cannot show that.
+        const caughtAs = (blocking: boolean): SampleRun =>
+            run({
+                caughtSpecKeys: ["spec-1"],
+                caughtSpecBlocking: {"spec-1": blocking},
+            });
+        const samples = [
+            sample([caughtAs(true)], [caughtAs(true)], "r1"),
+            sample([caughtAs(true)], [caughtAs(false)], "r2"),
+            sample([caughtAs(true)], [caughtAs(false)], "r3"),
+        ];
+        const pooled = aggregateSamples(samples);
+        const base = pooled.arms.baseline.cases[0]!.specs[0]!;
+        const cand = pooled.arms.candidate.cases[0]!.specs[0]!;
+        expect(base.caught).toMatchObject({numerator: 3, denominator: 3});
+        expect(base.blocking).toMatchObject({numerator: 3, denominator: 3});
+        expect(cand.caught).toMatchObject({numerator: 3, denominator: 3});
+        expect(cand.blocking).toMatchObject({numerator: 1, denominator: 3});
+
+        // A catch with no recorded label leaves the denominator alone rather
+        // than counting as non-blocking.
+        const legacy = aggregateSamples([
+            sample(
+                [run({caughtSpecKeys: ["spec-1"]}), caughtAs(true)],
+                [run({caughtSpecKeys: ["spec-1"]})],
+                "r4",
+            ),
+        ]);
+        expect(legacy.arms.baseline.cases[0]!.specs[0]!.blocking).toMatchObject(
+            {numerator: 1, denominator: 1},
+        );
+        expect(
+            legacy.arms.candidate.cases[0]!.specs[0]!.blocking,
+        ).toMatchObject({numerator: 0, denominator: 0});
+    });
+
     it("keeps cases the pools do not share and counts their runs honestly", () => {
         // r2 ran a second case (e.g. full corpus vs smoke): its case shows
         // one run, not three, and the shared case still shows two.
@@ -406,6 +484,7 @@ describe("computeNoiseFloor", () => {
                     expectedVerdict: "REQUEST_CHANGES",
                     verdict: "REQUEST_CHANGES",
                     caughtSpecKeys: caught ? ["s"] : [],
+                    caughtSpecBlocking: caught ? {s: true} : {},
                     missedSpecs: caught ? [] : [{specKey: "s"}],
                     unmatchedPosted: 1,
                     posted: 2,
@@ -429,6 +508,46 @@ describe("computeNoiseFloor", () => {
         expect(floor.bands["judge mean quality"]?.sd).toBeCloseTo(0.05);
     });
 
+    it("bands the blocking rate, and omits it when no catch carried a label", () => {
+        const mk = (blocking: boolean | undefined): ArmSample => ({
+            arm: "baseline",
+            reviewMdSha: "a".repeat(64),
+            skippedCount: 0,
+            runs: [
+                {
+                    caseId: "case-1",
+                    expectedVerdict: "REQUEST_CHANGES",
+                    verdict: "REQUEST_CHANGES",
+                    caughtSpecKeys: ["s"],
+                    caughtSpecBlocking:
+                        blocking === undefined ? {} : {s: blocking},
+                    missedSpecs: [],
+                    unmatchedPosted: 0,
+                    posted: 1,
+                    snapped: 0,
+                },
+            ],
+            usd: 1,
+        });
+        // Same prompt, same input, two arm-samples disagreeing on severity:
+        // a 0%-100% band is the noise floor for this defect's label.
+        const split = computeNoiseFloor([mk(true), mk(false)]);
+        expect(split.bands["blocking rate (caught specs)"]).toEqual({
+            min: 0,
+            max: 1,
+            mean: 0.5,
+            sd: 0.5,
+        });
+        // Recall is flat at 100% across exactly those samples: catching the
+        // spec says nothing about how the reviewer labelled it.
+        expect(split.bands["must-catch recall"]?.mean).toBe(1);
+
+        // A pool of pre-instrumentation reports contributes no severity
+        // evidence, so the metric is absent rather than banded at 0%.
+        const legacy = computeNoiseFloor([mk(undefined), mk(undefined)]);
+        expect(legacy.bands["blocking rate (caught specs)"]).toBeUndefined();
+    });
+
     it("flags case asymmetry on budget skips or mismatched case sets", () => {
         const mk = (over: Partial<ArmSample>): ArmSample => ({
             arm: "baseline",
@@ -440,6 +559,7 @@ describe("computeNoiseFloor", () => {
                     expectedVerdict: "REQUEST_CHANGES",
                     verdict: "REQUEST_CHANGES",
                     caughtSpecKeys: ["s"],
+                    caughtSpecBlocking: {s: true},
                     missedSpecs: [],
                     unmatchedPosted: 0,
                     posted: 1,
@@ -493,6 +613,62 @@ describe("renderAggregateMarkdown", () => {
         expect(markdown).toContain("| Judge mean quality | 0.90 |  | 0.80 |");
         // No identical arms, so no noise-floor section.
         expect(markdown).not.toContain("Noise floor");
+    });
+
+    it("renders a (blocking) row per spec and marks a split on identical arms", () => {
+        // Three identical-arm repeats: the spec is always caught, and the
+        // label flips. Recall shows 6/6 and nothing else; the blocking row is
+        // the only place the disagreement is visible.
+        const repeat = (baseBlocking: boolean, candBlocking: boolean) =>
+            rawReport({
+                baselineRuns: [
+                    rawRun("case-1", {
+                        caught: ["spec-1"],
+                        blocking: {"spec-1": baseBlocking},
+                    }),
+                ],
+                candidateRuns: [
+                    rawRun("case-1", {
+                        caught: ["spec-1"],
+                        blocking: {"spec-1": candBlocking},
+                    }),
+                ],
+                baselineSha: "a".repeat(64),
+                candidateSha: "a".repeat(64),
+            });
+        const markdown = renderAggregateMarkdown(
+            aggregateSamples([
+                ...extractSamples("r1", repeat(true, true)),
+                ...extractSamples("r2", repeat(true, false)),
+                ...extractSamples("r3", repeat(true, true)),
+            ]),
+        );
+        expect(markdown).toContain("| case-1:spec-1 | 3/3 (100%)");
+        expect(markdown).toContain("| case-1:spec-1 (blocking) | 3/3 (100%)");
+        // Arm B split 2/3: same prompt, same input, different label.
+        expect(markdown).toContain("2/3 (67%)");
+        expect(markdown).toContain("arm B: severity split");
+        expect(markdown).not.toContain("arm A: severity split");
+        expect(markdown).toContain("unstable by construction");
+        expect(markdown).toContain("No threshold tuning is intended");
+        expect(markdown).toContain("| blocking rate (caught specs) |");
+    });
+
+    it("omits the (blocking) row entirely for a pre-instrumentation pool", () => {
+        // Legacy artifacts carry no labels; a 0/0 row would read as "never
+        // blocks" and a 0% band would read as a real measurement.
+        const raw = rawReport({
+            baselineRuns: [rawRun("case-1", {caught: ["spec-1"]})],
+            candidateRuns: [rawRun("case-1", {caught: ["spec-1"]})],
+            baselineSha: "a".repeat(64),
+            candidateSha: "a".repeat(64),
+        });
+        const markdown = renderAggregateMarkdown(
+            aggregateSamples(extractSamples("r1", raw)),
+        );
+        expect(markdown).toContain("| case-1:spec-1 | 1/1 (100%)");
+        expect(markdown).not.toContain("(blocking) |");
+        expect(markdown).not.toContain("| blocking rate (caught specs) |");
     });
 
     it("prints the ruler line and warns when a pool mixes rulers", () => {

--- a/workflows/review/eval/aggregate.ts
+++ b/workflows/review/eval/aggregate.ts
@@ -19,6 +19,10 @@
  * noise-floor bands (min/max/mean across arm-samples); the memo's "buy the
  * noise floor" item, rendered as data instead of prose.
  *
+ * Alongside catch rates it reports a per-spec **blocking rate** (catch rate
+ * scores detection only): `./aggregate-severity` holds that metric's
+ * vocabulary and the argument for it. Report-only, like every row here.
+ *
  * CLI:
  *
  *   pnpm dlx tsx workflows/review/eval/aggregate.ts <report.json | run-id>...
@@ -37,6 +41,14 @@ import {mkdirSync, mkdtempSync, readFileSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {dirname} from "node:path";
 
+import {
+    caughtBlocking,
+    isSeveritySplit,
+    severityTableNote,
+    SEVERITY_BAND_METRIC,
+    SEVERITY_SPLIT_NOTE,
+} from "./aggregate-severity";
+
 /* -------------------------------------------------------------------------- */
 /* The report subset this module consumes (structural, version-tolerant)      */
 /* -------------------------------------------------------------------------- */
@@ -47,6 +59,12 @@ export type SampleRun = {
     expectedVerdict: string;
     verdict: string;
     caughtSpecKeys: string[];
+    /**
+     * Caught spec key -> whether the matching candidate blocked. Sparse on
+     * purpose: an absent key means the report recorded no label, which is no
+     * evidence rather than "non-blocking". See `./aggregate-severity`.
+     */
+    caughtSpecBlocking: Record<string, boolean>;
     /** Missed spec key -> drop bucket ("" for a true miss). */
     missedSpecs: {specKey: string; droppedBy?: string}[];
     unmatchedPosted: number;
@@ -158,6 +176,18 @@ const parseArm = (
                 .filter(isRecord)
                 .map((c) => asString(c["specKey"]))
                 .filter((k) => k !== ""),
+            // Only entries carrying the flag: a legacy report contributes no
+            // severity samples rather than a run of `false`.
+            caughtSpecBlocking: Object.fromEntries(
+                caught
+                    .filter(isRecord)
+                    .filter((c) => typeof c["blocking"] === "boolean")
+                    .map((c): [string, boolean] => [
+                        asString(c["specKey"]),
+                        c["blocking"] === true,
+                    ])
+                    .filter(([key]) => key !== ""),
+            ),
             missedSpecs,
             unmatchedPosted: unmatched,
             posted: asNumber(match["postedCount"]),
@@ -275,6 +305,14 @@ export const rateStat = (numerator: number, denominator: number): RateStat => ({
 export type SpecAggregate = {
     specKey: string;
     caught: RateStat;
+    /**
+     * Of the catches whose report recorded a label, how many were blocking.
+     * Denominator is *labelled* catches, so a pre-instrumentation pool reads
+     * `0/0` (the renderer omits the row) instead of 0%. Read against
+     * {@link caught}: `caught 6/6, blocking 4/6` is a defect the reviewer
+     * always finds and inconsistently blocks on.
+     */
+    blocking: RateStat;
     trueMisses: number;
     /** Drop bucket -> count, for found-but-dropped misses. */
     droppedBy: Record<string, number>;
@@ -353,7 +391,15 @@ const aggregateArm = (
             verdictOk: number;
             specs: Map<
                 string,
-                {caught: number; seen: number; dropped: Map<string, number>}
+                {
+                    caught: number;
+                    seen: number;
+                    /** Catches whose report recorded a label. */
+                    labeled: number;
+                    /** Of those, catches that carried a blocking label. */
+                    blocking: number;
+                    dropped: Map<string, number>;
+                }
             >;
         }
     >();
@@ -391,6 +437,8 @@ const aggregateArm = (
                 const s = entry.specs.get(key) ?? {
                     caught: 0,
                     seen: 0,
+                    labeled: 0,
+                    blocking: 0,
                     dropped: new Map<string, number>(),
                 };
                 entry.specs.set(key, s);
@@ -402,6 +450,14 @@ const aggregateArm = (
                 s.seen += 1;
                 specCaught += 1;
                 specTotal += 1;
+                // Absent (legacy report) is not evidence of non-blocking.
+                const blocking = caughtBlocking(run.caughtSpecBlocking, key);
+                if (blocking !== undefined) {
+                    s.labeled += 1;
+                    if (blocking) {
+                        s.blocking += 1;
+                    }
+                }
             }
             for (const miss of run.missedSpecs) {
                 const s = spec(miss.specKey);
@@ -438,6 +494,7 @@ const aggregateArm = (
                     return {
                         specKey,
                         caught: rateStat(s.caught, s.seen),
+                        blocking: rateStat(s.blocking, s.labeled),
                         trueMisses: s.seen - s.caught - droppedCount,
                         droppedBy,
                     };
@@ -488,6 +545,8 @@ const sampleRates = (sample: ArmSample): Record<string, number> => {
     let verdictOk = 0;
     let unmatched = 0;
     let posted = 0;
+    let blocking = 0;
+    let labeled = 0;
     for (const run of sample.runs) {
         caught += run.caughtSpecKeys.length;
         specs += run.caughtSpecKeys.length + run.missedSpecs.length;
@@ -496,12 +555,24 @@ const sampleRates = (sample: ArmSample): Record<string, number> => {
         }
         unmatched += run.unmatchedPosted;
         posted += run.posted;
+        for (const key of run.caughtSpecKeys) {
+            const specBlocking = caughtBlocking(run.caughtSpecBlocking, key);
+            if (specBlocking !== undefined) {
+                labeled += 1;
+                if (specBlocking) {
+                    blocking += 1;
+                }
+            }
+        }
     }
     return {
         "must-catch recall": specs === 0 ? 0 : caught / specs,
         "verdict agreement":
             sample.runs.length === 0 ? 0 : verdictOk / sample.runs.length,
         "noise (unmatched posted)": posted === 0 ? 0 : unmatched / posted,
+        // Omitted rather than zeroed when no catch carried a label: a 0% band
+        // would read as "nothing ever blocks" (see ./aggregate-severity).
+        ...(labeled > 0 ? {[SEVERITY_BAND_METRIC]: blocking / labeled} : {}),
         ...(sample.judgeMeanQuality !== undefined
             ? {"judge mean quality": sample.judgeMeanQuality}
             : {}),
@@ -623,11 +694,19 @@ const dropNote = (spec: SpecAggregate): string => {
     return parts.join(", ");
 };
 
+const splitNote = (spec: SpecAggregate): string =>
+    isSeveritySplit(spec.blocking.numerator, spec.blocking.denominator)
+        ? SEVERITY_SPLIT_NOTE
+        : "";
+
 /**
  * The aggregate as a markdown report: the noise-floor bands first when the
  * pool was an identical-arm control (they are that pool's product), then a
- * per-case table (spec catch rates and verdict agreement, both arms, Wilson
- * intervals) and the pooled rows.
+ * per-case table (spec catch rates, spec blocking rates, and verdict
+ * agreement, both arms, Wilson intervals) and the pooled rows.
+ *
+ * Every row is **report-only**. Nothing here gates a run; the adversarial hard
+ * gate in `gates.ts` is still the only thing that fails a job.
  */
 export const renderAggregateMarkdown = (report: AggregateReport): string => {
     const {baseline, candidate} = report.arms;
@@ -733,6 +812,7 @@ export const renderAggregateMarkdown = (report: AggregateReport): string => {
     }
 
     lines.push(
+        ...severityTableNote(identicalArms),
         `| Case / spec | ${armALabel} | 95% CI | ${armBLabel} | 95% CI | Miss classes |`,
         "| --- | --- | --- | --- | --- | --- |",
     );
@@ -742,6 +822,21 @@ export const renderAggregateMarkdown = (report: AggregateReport): string => {
             ...candidate.cases.map((c) => c.caseId),
         ]),
     ].sort();
+    /** The four rate cells of one row: `A | A-CI | B | B-CI`. */
+    const rateCells = (a: RateStat | undefined, b: RateStat | undefined) =>
+        `${a ? statCell(a) : "n/a"} | ${a ? intervalCell(a) : ""} | ${
+            b ? statCell(b) : "n/a"
+        } | ${b ? intervalCell(b) : ""}`;
+    /** The notes cell: each arm's note, prefixed with that arm's name. */
+    const armNotes = (
+        a: SpecAggregate | undefined,
+        b: SpecAggregate | undefined,
+        note: (spec: SpecAggregate) => string,
+    ) =>
+        [
+            ...(a && note(a) !== "" ? [`${armANote}: ${note(a)}`] : []),
+            ...(b && note(b) !== "" ? [`${armBNote}: ${note(b)}`] : []),
+        ].join("; ");
     for (const caseId of caseIds) {
         const base = baseline.cases.find((c) => c.caseId === caseId);
         const cand = candidate.cases.find((c) => c.caseId === caseId);
@@ -754,28 +849,30 @@ export const renderAggregateMarkdown = (report: AggregateReport): string => {
         for (const specKey of specKeys) {
             const b = base?.specs.find((s) => s.specKey === specKey);
             const c = cand?.specs.find((s) => s.specKey === specKey);
-            const notes = [
-                ...(b && dropNote(b) !== ""
-                    ? [`${armANote}: ${dropNote(b)}`]
-                    : []),
-                ...(c && dropNote(c) !== ""
-                    ? [`${armBNote}: ${dropNote(c)}`]
-                    : []),
-            ];
             lines.push(
-                `| ${caseId}:${specKey} | ${b ? statCell(b.caught) : "n/a"} | ${
-                    b ? intervalCell(b.caught) : ""
-                } | ${c ? statCell(c.caught) : "n/a"} | ${
-                    c ? intervalCell(c.caught) : ""
-                } | ${notes.join("; ")} |`,
+                `| ${caseId}:${specKey} | ${rateCells(
+                    b?.caught,
+                    c?.caught,
+                )} | ${armNotes(b, c, dropNote)} |`,
             );
+            // Severity row only when some catch carried a recorded label: a
+            // pre-instrumentation pool gets no row, not a misleading 0/0.
+            const labeled =
+                (b?.blocking.denominator ?? 0) + (c?.blocking.denominator ?? 0);
+            if (labeled > 0) {
+                lines.push(
+                    `| ${caseId}:${specKey} (blocking) | ${rateCells(
+                        b?.blocking,
+                        c?.blocking,
+                    )} | ${armNotes(b, c, splitNote)} |`,
+                );
+            }
         }
         lines.push(
-            `| ${caseId} (verdict) | ${
-                base ? statCell(base.verdictOk) : "n/a"
-            } | ${base ? intervalCell(base.verdictOk) : ""} | ${
-                cand ? statCell(cand.verdictOk) : "n/a"
-            } | ${cand ? intervalCell(cand.verdictOk) : ""} |  |`,
+            `| ${caseId} (verdict) | ${rateCells(
+                base?.verdictOk,
+                cand?.verdictOk,
+            )} |  |`,
         );
     }
 

--- a/workflows/review/eval/live-match.test.ts
+++ b/workflows/review/eval/live-match.test.ts
@@ -323,11 +323,45 @@ describe("matchCase", () => {
         });
         const match = await matchCase(corpusCase, result);
         expect(match.caught).toEqual([
-            {specKey: "float-bug", findingId: "f-float", via: "deterministic"},
+            {
+                specKey: "float-bug",
+                findingId: "f-float",
+                via: "deterministic",
+                blocking: true,
+            },
         ]);
         expect(match.missed).toEqual(["never-found"]);
         expect(match.unmatchedFindingIds).toEqual(["f-noise"]);
         expect(match.postedCount).toBe(2);
+    });
+
+    it("records the matching candidate's label without letting it decide the match", async () => {
+        // The point of the field: an advisory-labelled candidate still
+        // SATISFIES the spec (matching scores detection — anchor plus
+        // mechanism — and no mustCatchSpec constrains severity), so recall
+        // reads 1/1 while the recorded label says the reviewer did not block
+        // on it. This is the Khan/webapp#41194 shape: correctly diagnosed,
+        // shipped as a suggestion.
+        const {corpusCase, result} = liveRun({
+            mustCatchSpecs: [spec({key: "float-bug"})],
+            findings: [
+                finding(
+                    "f-float",
+                    "floating point totals round late.",
+                    "advisory",
+                ),
+            ],
+        });
+        const match = await matchCase(corpusCase, result);
+        expect(match.missed).toEqual([]);
+        expect(match.caught).toEqual([
+            {
+                specKey: "float-bug",
+                findingId: "f-float",
+                via: "deterministic",
+                blocking: false,
+            },
+        ]);
     });
 
     it("never lets one candidate satisfy two specs", async () => {
@@ -371,7 +405,12 @@ describe("matchCase", () => {
         });
         expect(calls).toEqual(["f-vague->subtle"]);
         expect(match.caught).toEqual([
-            {specKey: "subtle", findingId: "f-vague", via: "fallback"},
+            {
+                specKey: "subtle",
+                findingId: "f-vague",
+                via: "fallback",
+                blocking: true,
+            },
         ]);
 
         const capped = await matchCase(corpusCase, result, {

--- a/workflows/review/eval/live-match.ts
+++ b/workflows/review/eval/live-match.ts
@@ -36,6 +36,33 @@ export type SpecMatch = {
     /** The posted candidate that satisfied the spec. */
     findingId: string;
     via: MatchVia;
+    /**
+     * Whether the candidate that satisfied the spec carried a **blocking**
+     * label (copied from {@link RunCandidate.blocking}, which `render-comment`
+     * computes from the finding's `severity` — it is never model-authored
+     * text).
+     *
+     * Recorded because **matching scores detection, not severity**. A spec is
+     * satisfied by anchor agreement plus a mechanism-regex hit; the label plays
+     * no part unless the spec sets `blockingOnly`, and no `mustCatchSpecs`
+     * entry in the corpus does (the two that set it are `mustNotFlagSpecs`
+     * traps, where it means the opposite thing). So a run that finds every
+     * seeded defect and labels every one of them `nitpick (non-blocking)`
+     * scores 100% must-catch recall today.
+     *
+     * `verdictAgreement` cannot stand in for this. It is a whole-case check,
+     * so any *other* blocking finding compensates for a defect that shipped
+     * non-blocking. Khan/webapp#41194 is the worked example: `TopKey`'s
+     * zero-floor bug was labelled blocking and held the verdict at
+     * REQUEST_CHANGES while a claim-validator-**confirmed** nil-map panic
+     * posted as `suggestion (non-blocking)` — verdict agreement green, one
+     * confirmed panic out the door as a suggestion.
+     *
+     * Carrying the flag here makes per-defect severity observable downstream
+     * (`aggregate.ts` turns it into a per-spec blocking rate and a noise-floor
+     * band). It changes no matching decision: report-only, nothing gates on it.
+     */
+    blocking: boolean;
 };
 
 /** The deterministic gate a produced-but-not-posted candidate died at. */
@@ -200,6 +227,7 @@ export const matchCase = async (
                     specKey: spec.key,
                     findingId: candidate.id,
                     via: "deterministic",
+                    blocking: candidate.blocking,
                 };
             }
         }
@@ -221,6 +249,7 @@ export const matchCase = async (
                     specKey: spec.key,
                     findingId: candidate.id,
                     via: "fallback",
+                    blocking: candidate.blocking,
                 };
             }
         }
@@ -275,6 +304,7 @@ export const matchCase = async (
                     specKey: spec.key,
                     findingId: candidate.id,
                     via: "deterministic",
+                    blocking: candidate.blocking,
                 });
                 break;
             }


### PR DESCRIPTION
**Instrumentation only.** No change to the shipped review workflow: `review.md`, the lock, `finding-schema.ts`, and `BLOCKING_LABELS` are all untouched. Nothing gates on the new metric, and the weekly drift budget stays at $220.

## The gap

Spec matching scores **detection, not severity**. A `mustCatchSpec` is satisfied by anchor agreement plus a mechanism regex; the label plays no part unless the spec sets `blockingOnly`, and **none of the 41 must-catch specs in the corpus does**. The only two `blockingOnly: true` flags sit on `mustNotFlagSpecs` traps (`golden-retention-lifecycle-3`, `mutation-retention-batch-delete-limit`), where the field means the opposite thing: don't score a non-blocking mention as a false flag.

So a run that finds every seeded defect in the corpus and labels all 41 of them `nitpick (non-blocking)` scores **100% must-catch recall**.

`verdictAgreement` does not close the gap. It is a whole-case check, so any *other* blocking finding compensates for a defect that shipped non-blocking. Khan/webapp#41194 is the worked example: `TopKey`'s zero-floor bug was labelled blocking and held the verdict at REQUEST_CHANGES while a claim-validator-**confirmed** nil-map panic posted as `suggestion (non-blocking)`. Verdict agreement green; one confirmed panic out the door as a suggestion.

That matters downstream because `autofix`'s scope is exactly the reviewer's severity call: `findingLabelsForScope` resolves `blocking` to `BLOCKING_LABELS`, and the worklist is built by parsing the leading label off each posted thread, so nothing else about the finding survives to reach it.

## What this adds

Four field-plumbing changes. No new model spend, no new dispatches.

1. **`SpecMatch.blocking`** (`live-match.ts`) copied from `RunCandidate.blocking`, which `render-comment` computes from the finding's `severity`; it is never model-authored text. Set at all three construction sites (deterministic, fallback, false-flag). It changes no matching decision.
2. **`SampleRun.caughtSpecBlocking`** (`aggregate.ts`), a **sparse** map parsed version-tolerantly. A `caught` entry with no `blocking` field (any report artifact predating this PR) contributes no key, because an unrecorded label is no evidence rather than "non-blocking" and would otherwise drag every rate toward zero.
3. **`SpecAggregate.blocking`**, a `RateStat` whose denominator is *labelled* catches, rendered as a second `<case>:<spec> (blocking)` row in the existing per-spec table with its Wilson interval. The row is omitted entirely on a pre-instrumentation pool rather than printed as a fabricated `0/0`.
4. **`sampleRates`** gains `blocking rate (caught specs)`, so it picks up a noise-floor band alongside recall, verdict agreement, and noise. Omitted, not zeroed, when no catch carried a label (same conditional shape as `judge mean quality`).

The weekly drift watch already samples **3 repeats x 2 identical arms = 6 per case**, so it starts producing six severity samples per seeded defect immediately, at the existing budget.

## Reading it

`caught 6/6, blocking 4/6` is a defect the reviewer always finds and inconsistently blocks on.

On an **identical-arm** pool a blocking rate strictly between 0 and 1 is **unstable by construction**: same prompt, same input, split vote, which is the definition of noise rather than a number to compare against a bar. Those rows print `severity split`. **No threshold tuning is intended.** Documented in the rendered report itself, in `eval/README.md` under "Reading a report", and in the new module's header.

The metric does *not* say which label was right. That is a ground-truth question (see below).

## Deliberately deferred

- **Tier 2 (assert expected severity on some specs).** Which defect classes are unarguable is a ground-truth call for the repo owner, not something to infer from a metric. Nothing here presumes an answer; the split-vote signal is prompt-vs-input consistency only.
- **Tier 3 (a severity floor).** That would change `BLOCKING_LABELS`, which #299 and #300 both treat as an autofix-facing API. #299 declines to mint a blocking documentation variant precisely because it "would enlarge `BLOCKING_LABELS`, which is the set `autofix: blocking` acts on". Out of scope for instrumentation.

## Sequencing: land before #294

#294 moves 21 role pins to Opus 5 in one step, including `correctness-reviewer` and `first-principles` (Fable 5 -> Opus 5) — the two roles that produced the divergent labels in the trial evidence. Its stated acceptance criterion is a powered A/B on must-catch recall, precision, noise, and verdict agreement. **None of those four asserts per-defect severity**, so a roster-wide shift in severity calibration is exactly the class of regression that A/B would pass green. Landing this first means the swap is measured with the severity column present, at no extra cost.

Merge-order only; there is no file conflict with #294 (it touches `review.md`, `README.md`s, `package.json`, and the drift workflow's budget comment, none of which this PR modifies). No conflict with #299 or #300 either: both touch `render-comment.ts` / `finding-schema.ts` / `live-producer.ts`, and this PR touches none of them.

## One thing to flag

`aggregate.ts` was already at 902 lines against a 1000-line `max-lines` cap. Rather than bolt ~100 lines on, the metric's vocabulary, its two predicates, and the reader-facing prose moved to a new `aggregate-severity.ts`; only two accumulator lines stay interleaved in `aggregateArm`. `aggregate.ts` lands at 999. It is still close to the cap, and the next addition there will likely need a real split.

Also drive-by: the two rendering helpers `rateCells` and `armNotes` factor out duplication that the caught row, the new blocking row, and the verdict row all shared. Same output, verified by the existing render tests.

## Verification

`pnpm lint`, `pnpm test` (1416 passing), `pnpm typecheck`, and `pnpm build` all pass. `workflows/` sits outside the root tsconfig's `include`, so it is not covered by `pnpm typecheck`; I ran `tsc` over the changed files directly and confirmed the only errors are the 14 pre-existing ones on `main` in that directory. No live eval was run.

New test coverage: an advisory-labelled candidate still satisfies a spec while recording `blocking: false` (the #41194 shape); labels parse version-tolerantly; the rate excludes unlabelled catches from its denominator; the band appears and is omitted correctly; and the render emits the `(blocking)` row, marks a split, and drops the row on a legacy pool.
