### PR TITLE
[🔥AUDIT🔥] review: split the roster concern out of dispatch.ts, which is over its line cap

### DIFF
--- a/.changeset/review-dispatch-roster-split.md
+++ b/.changeset/review-dispatch-roster-split.md
@@ -1,0 +1,7 @@
+---
+"review": patch
+---
+
+Split the Step 3 roster concern out of `dispatch.ts` into `dispatch-roster.ts` (`DEFAULT_FINDERS`, `SHED_RANKING`, `Roster`, `RosterShed`, `computeRoster`), re-exported from `dispatch.ts` so callers and tests keep one import surface. No behaviour change: the moved code is byte-identical and every existing test passes unmodified.
+
+The trigger was a lint failure on main that neither contributing PR could see. `@khanacademy/eslint-config` caps a file at 1000 lines; #302 took `dispatch.ts` to exactly 1000, and the one line #299 added to the shed ranking took it to 1001. Both were green against their own bases, so the collision existed only in the merge. `dispatch.ts` is now 920 lines, and the split follows the precedent `dispatch-contracts.ts` already set for the same budget.

--- a/workflows/review/lib/dispatch-roster.ts
+++ b/workflows/review/lib/dispatch-roster.ts
@@ -1,0 +1,108 @@
+/**
+ * The Step 3 dispatch roster: which finding producers a run dispatches, in
+ * what order, and which ones the invocation cap sheds. Split out of
+ * `dispatch.ts` for the same reason `dispatch-contracts.ts` was, its
+ * max-lines budget, and following the same precedent (router, budgets,
+ * credit-cap): one concern per module, no behaviour change.
+ *
+ * The immediate cause of the split is worth recording, because it will
+ * recur. `dispatch.ts` sat at exactly 1000 lines after #302 and the shared
+ * `@khanacademy/eslint-config` caps a file at 1000, so the single line
+ * #299 added to the shed ranking took it to 1001. Both PRs were green
+ * against their own bases and the collision only existed in the merge, which
+ * no per-PR lint run can see. Extracting a concern restores headroom; raising
+ * the cap locally would deviate from the house config.
+ *
+ * Determinism boundary: pure functions over staged routing JSON. No model
+ * call, no filesystem, no prose about the code under review.
+ */
+
+/** The always-on finders (pattern-triage and thread-reconciler excluded). */
+export const DEFAULT_FINDERS = [
+    "correctness-reviewer",
+    "skill-auditor",
+] as const;
+
+/**
+ * The Step 3 dispatch/shed ranking, first-shed first. Fill order under the
+ * invocation cap is this list reversed after the defaults and matched
+ * lenses. An enabled reviewer this table does not know sheds after
+ * `conventions` (generic before targeted).
+ */
+export const SHED_RANKING = [
+    "documentation",
+    "conventions",
+    "first-principles",
+    "holistic",
+    "completeness",
+    "test-adequacy",
+] as const;
+
+export type RosterShed = {name: string; cause: "budget"};
+
+export type Roster = {
+    /** Finding producers to dispatch, in dispatch-ranking order. */
+    finders: string[];
+    /** Planned finding producers shed under the invocation cap. */
+    shed: RosterShed[];
+    /** Whether pattern-triage runs (full/scoped only). */
+    triage: boolean;
+    /** Whether the reconciler runs (staged threads exist). */
+    reconcile: boolean;
+};
+
+/**
+ * Compute the dispatch roster per the staged depth plan and routing, capped
+ * by `runBudget.maxReviewerInvocations` in the Step 3 dispatch ranking
+ * (defaults, then matched lenses, then opt-ins by inverse shed order), every
+ * capped-out entry recorded as a planned shed. Pipeline steps (triage,
+ * reconciler, validator) never consume a slot.
+ */
+export const computeRoster = (
+    depth: string,
+    routing: {
+        enabledReviewers?: unknown;
+        lensesToSpawn?: unknown;
+        runBudget?: {maxReviewerInvocations?: unknown};
+    },
+    hasThreads: boolean,
+): Roster => {
+    if (depth === "fast") {
+        return {finders: [], shed: [], triage: false, reconcile: hasThreads};
+    }
+    if (depth === "flip-gated") {
+        return {
+            finders: ["correctness-reviewer"],
+            shed: [],
+            triage: false,
+            reconcile: hasThreads,
+        };
+    }
+    const strings = (value: unknown): string[] =>
+        Array.isArray(value)
+            ? value.filter((v): v is string => typeof v === "string")
+            : [];
+    const lenses = strings(routing.lensesToSpawn);
+    const enabled = strings(routing.enabledReviewers).filter(
+        (name) => !lenses.includes(name),
+    );
+    const optIns = [...enabled].sort((a, b) => {
+        const rank = (name: string): number => {
+            const index = (SHED_RANKING as readonly string[]).indexOf(name);
+            return index === -1 ? -0.5 : index;
+        };
+        return rank(b) - rank(a);
+    });
+    const ranked = [...DEFAULT_FINDERS, ...lenses, ...optIns];
+
+    const capRaw = routing.runBudget?.maxReviewerInvocations;
+    const cap =
+        typeof capRaw === "number" && Number.isInteger(capRaw) && capRaw >= 0
+            ? capRaw
+            : ranked.length;
+    const finders = ranked.slice(0, Math.max(cap, DEFAULT_FINDERS.length));
+    const shed = ranked
+        .slice(finders.length)
+        .map((name): RosterShed => ({name, cause: "budget"}));
+    return {finders, shed, triage: true, reconcile: hasThreads};
+};

--- a/workflows/review/lib/dispatch.ts
+++ b/workflows/review/lib/dispatch.ts
@@ -61,6 +61,7 @@ import {
     type Candidate,
     type Claim,
 } from "./dispatch-contracts";
+import {computeRoster, type RosterShed} from "./dispatch-roster";
 import {
     applyProvenanceGate,
     type DiffProvenance,
@@ -81,6 +82,13 @@ export {
     type ContractKind,
     type Verification,
 } from "./dispatch-contracts";
+export {
+    computeRoster,
+    DEFAULT_FINDERS,
+    SHED_RANKING,
+    type Roster,
+    type RosterShed,
+} from "./dispatch-roster";
 export {
     dedupeClaims,
     suppressOpenThreadDuplicates,
@@ -156,22 +164,6 @@ const DEFAULT_CONCURRENCY = 4;
 const TRIAGE = "pattern-triage";
 const RECONCILER = "thread-reconciler";
 const VALIDATOR = "claim-validator";
-const DEFAULT_FINDERS = ["correctness-reviewer", "skill-auditor"] as const;
-
-/**
- * The Step 3 dispatch/shed ranking, first-shed first. Fill order under the
- * invocation cap is this list reversed after the defaults and matched
- * lenses. An enabled reviewer this table does not know sheds after
- * `conventions` (generic before targeted).
- */
-const SHED_RANKING = [
-    "documentation",
-    "conventions",
-    "first-principles",
-    "holistic",
-    "completeness",
-    "test-adequacy",
-] as const;
 
 /* -------------------------------------------------------------------------- */
 /* Agent definitions (.claude/agents/<name>.md)                               */
@@ -227,79 +219,6 @@ const loadAgents = (
         }
     }
     return agents;
-};
-
-/* -------------------------------------------------------------------------- */
-/* Roster                                                                     */
-/* -------------------------------------------------------------------------- */
-
-export type RosterShed = {name: string; cause: "budget"};
-
-export type Roster = {
-    /** Finding producers to dispatch, in dispatch-ranking order. */
-    finders: string[];
-    /** Planned finding producers shed under the invocation cap. */
-    shed: RosterShed[];
-    /** Whether pattern-triage runs (full/scoped only). */
-    triage: boolean;
-    /** Whether the reconciler runs (staged threads exist). */
-    reconcile: boolean;
-};
-
-/**
- * Compute the dispatch roster per the staged depth plan and routing, capped
- * by `runBudget.maxReviewerInvocations` in the Step 3 dispatch ranking
- * (defaults, then matched lenses, then opt-ins by inverse shed order), every
- * capped-out entry recorded as a planned shed. Pipeline steps (triage,
- * reconciler, validator) never consume a slot.
- */
-export const computeRoster = (
-    depth: string,
-    routing: {
-        enabledReviewers?: unknown;
-        lensesToSpawn?: unknown;
-        runBudget?: {maxReviewerInvocations?: unknown};
-    },
-    hasThreads: boolean,
-): Roster => {
-    if (depth === "fast") {
-        return {finders: [], shed: [], triage: false, reconcile: hasThreads};
-    }
-    if (depth === "flip-gated") {
-        return {
-            finders: ["correctness-reviewer"],
-            shed: [],
-            triage: false,
-            reconcile: hasThreads,
-        };
-    }
-    const strings = (value: unknown): string[] =>
-        Array.isArray(value)
-            ? value.filter((v): v is string => typeof v === "string")
-            : [];
-    const lenses = strings(routing.lensesToSpawn);
-    const enabled = strings(routing.enabledReviewers).filter(
-        (name) => !lenses.includes(name),
-    );
-    const optIns = [...enabled].sort((a, b) => {
-        const rank = (name: string): number => {
-            const index = (SHED_RANKING as readonly string[]).indexOf(name);
-            return index === -1 ? -0.5 : index;
-        };
-        return rank(b) - rank(a);
-    });
-    const ranked = [...DEFAULT_FINDERS, ...lenses, ...optIns];
-
-    const capRaw = routing.runBudget?.maxReviewerInvocations;
-    const cap =
-        typeof capRaw === "number" && Number.isInteger(capRaw) && capRaw >= 0
-            ? capRaw
-            : ranked.length;
-    const finders = ranked.slice(0, Math.max(cap, DEFAULT_FINDERS.length));
-    const shed = ranked
-        .slice(finders.length)
-        .map((name): RosterShed => ({name, cause: "budget"}));
-    return {finders, shed, triage: true, reconcile: hasThreads};
 };
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
🖍 _This is an audit!_ 🖍

## Summary:
main is red on lint, and neither PR that caused it could have seen it.
`@khanacademy/eslint-config` sets max-lines to 1000. #302 took
workflows/review/lib/dispatch.ts to exactly 1000 lines; the single line #299
added to SHED_RANKING took it to 1001. Each PR was green against its own
base, so the violation existed only in the merge, which is invisible to a
per-PR lint run. Every open PR in the repo inherits the failure, including
#300.

Fixed by extracting a concern rather than by reclaiming a line, so the next
addition does not land in the same place, and rather than raising the cap,
which lives in the shared Khan config and would be a house-rule deviation.
DEFAULT_FINDERS, SHED_RANKING, Roster, RosterShed and computeRoster move to
dispatch-roster.ts and are re-exported from dispatch.ts, which already
advertises one import surface for the dispatch machinery. The moved code is
byte-identical; dispatch.ts goes 1001 -> 920 lines and the new module is 108.

Verified: 1573 tests pass unmodified, typecheck clean, and eslint over
everything CI lints (actions, utils, workflows, minus the ignorePatterns
paths) reports zero errors. Worth recording for next time: a plain local
`pnpm run lint` cannot reproduce CI inside a git worktree under .claude,
because eslint skips dot-directories by default and silently ignores the
whole tree; `--resolve-plugins-relative-to . --no-ignore` scoped to the CI
paths is what actually reproduces it.

## Test plan:

- `pnpm exec vitest run`: 1573 tests pass, none modified by this change.
- `pnpm run typecheck`: clean.
- Lint, the check this PR exists to fix: `pnpm exec eslint --resolve-plugins-relative-to . --no-ignore --ext .js,.mjs,.ts actions utils workflows`, filtered to exclude the `ignorePatterns` corpus trees, reports **0 errors**. Before the change the same command reports the `max-lines` error on `dispatch.ts`.
- `git show --stat` confirms the move is a move: no line of `computeRoster` or the ranking changed.

Unblocks every open PR in the repo, #300 included, since they all contain main's `dispatch.ts`. #300 needs no changes of its own; it goes green once this lands.
