### PR TITLE
review: enable the documentation reviewer in this repo

### DIFF
--- a/.github/aw/review/ROUTING
+++ b/.github/aw/review/ROUTING
@@ -10,8 +10,21 @@
 # No specialist lenses are enabled: the eleven lens prompts target webapp's backend
 # domains (auth resolvers, migrations, federation, ...) and none maps to this repo's
 # supply-chain surface. Whole-change reviewers mirror webapp's eval-justified roster.
-
-enable holistic,completeness,test-adequacy,first-principles,conventions
+#
+# `documentation` is the newest of those and is the one worth justifying here, because
+# this repo is mostly prose that behaves like code. The reviewer prompts, this file, and
+# the config under .github/aw/review/ carry their rationale in comments because the code
+# cannot show it, and a comment that the diff falsified is a real defect class here rather
+# than a style nit -- the semver-as-behavior-contract discipline in workflows/review/
+# depends on the surrounding prose still being true. Nothing else checks that: the
+# reviewer's own tests cover lib/, not the prompts.
+#
+# Two supporting facts. Its policy is inline in the shared review.md, so enabling it adds
+# no consumer config and no required runtime import. And this repo already defines an
+# `autofix: docs` label scope (.github/workflows/autofix.md), which until now could never
+# match anything, because a docs-scoped autofix selects threads by the
+# `suggestion (non-blocking, documentation)` label that only this reviewer mints.
+enable holistic,completeness,test-adequacy,first-principles,conventions,documentation
 
 # Repeat reviews of the same PR run thread reconciliation plus the full
 # enabled roster over the new hunks (scoped staging); the first full review


### PR DESCRIPTION
## What

Adds `documentation` to this repo's own `enable` roster in `.github/aw/review/ROUTING`.
One line, plus the comment justifying it.

This also makes the existing comment above that line true. It already claimed the
whole-change reviewers "mirror webapp's eval-justified roster", but webapp enables six and
we enabled five.

## Why here

This repo is mostly prose that behaves like code. The reviewer prompts, `ROUTING`, and the
config under `.github/aw/review/` carry their rationale in comments precisely because the
code cannot show it. That makes a comment the diff falsified a real defect class here
rather than a style nit: the semver-as-behavior-contract discipline in `workflows/review/`
depends on the surrounding prose still being true, and nothing checks that today. The
reviewer's own tests cover `lib/`, not the prompts.

## Why it's cheap

- The policy is inline in the shared `review.md`, so this adds **no** consumer config file
  and no new required `{{#runtime-import}}`.
- Advisory-only: findings render as `suggestion (non-blocking, documentation)` and never
  block a merge.
- Volume-capped by the reviewer's own definition: 1 finding per comment, 2 per file, 5 per
  review.

## It makes an existing surface reachable

`.github/workflows/autofix.md` already defines an `autofix: docs` label scope. Until now
that scope could never match anything in this repo, because a docs-scoped autofix selects
threads by parsing the `suggestion (non-blocking, documentation)` label off each posted
comment, and only this reviewer mints it. Note that `autofix: docs` stays
loop-ineligible by construction (`workflows/autofix/lib/scope.ts`); this only makes the
human-armed label useful.

## Verified

`workflows/review/lib/check-consumer-config.ts` (from #317) parses the new roster:

```
ROUTING
  present           yes
  enabled reviewers holistic, completeness, test-adequacy, first-principles, conventions, documentation
  re-review         scoped
```

No recompile needed: `ROUTING` is read at run time by the router, not embedded at compile
time, so `review.lock.yml` is untouched. No changeset needed: `.github/` is excluded from
`check-for-changeset`.

## Not in scope, but surfaced while checking this

Running the checker over all 432 tracked files reports 27 that match no `tier=` rule and
fall to the router's default `low`. Most are unremarkable, but one group is not:
**`workflows/autofix/lib/*.ts` (6 files) are `low`.** `workflows/review/lib/**` is
`tier=high`, and autofix *pushes commits to PRs*, so this looks like an oversight rather
than a decision. `.github/aw/actions-lock.json` (the SHA pins for every third-party action
the compiled workflows run) and `.github/REVIEWERS` (the ownership map that drives reviewer
routing) are also unrated. Worth its own PR with someone deciding each tier deliberately.