### PR TITLE
review: honour `linguist-generated=false` the way git does

### DIFF
--- a/.changeset/gitattributes-negation.md
+++ b/.changeset/gitattributes-negation.md
@@ -1,0 +1,34 @@
+---
+"review": minor
+---
+
+review: honour `linguist-generated=false` the way git does, so deliberately un-marked files get reviewed
+
+The router read `.gitattributes` as a set of "generated globs" and asked whether a
+path matched *any* of them. Git resolves an attribute per path by the **last**
+matching line, so a negation placed after a broad glob is how a repo says "this
+subtree is generated, except this part". The reviewer discarded those negations
+while parsing, which meant it silently skipped review of exactly the files a repo
+had gone out of its way to keep visible.
+
+`parseGitattributesGenerated` now returns ordered `GeneratedRule[]`
+(`{pattern, generated}`) instead of a flat pattern list, keeping negations rather
+than dropping them, and `isGenerated` scans in reverse and returns the first
+matching rule's verdict. A line that never mentions the attribute is not a rule at
+all, so it cannot shadow one. `RouterConfig.generatedPatterns` is renamed to
+`generatedRules` to match what it now carries.
+
+Found while onboarding `Khan/agent-settings` (Khan/agent-settings#48), whose
+`.gitattributes` marks the installer-written `.claude/**`, `.codex/**`, `.cursor/**`
+and `.pi/**` output generated and then un-marks `.claude/skills/**` and
+`.pi/git/**` with a comment saying to keep them visible in diffs. Its
+`new-repo-config` skill — executable prose that steers every Claude session in that
+repo — resolved to `trivial (generated)` and was excluded from review; it now
+resolves to `medium` and is reviewed.
+
+Blast radius is narrow and one-directional (strictly more review, never less):
+only a repo that actually writes a negation after a broader `=true` glob changes at
+all. `Khan/actions` and `Khan/frontend` have no negations, and webapp's single one
+(`services/ai-guide/cmd/componentgen/main.go linguist-generated=false`) exists to
+counter Linguist's content heuristic rather than an earlier `.gitattributes` rule,
+so no earlier rule matches that path and its classification is unchanged.

--- a/workflows/review/eval/live-producer.ts
+++ b/workflows/review/eval/live-producer.ts
@@ -737,7 +737,7 @@ export const produceLive = async (
     // diff the staging already wrote); `flip-gated` keeps only the correctness
     // pass; `fast` keeps none.
     const routerConfig: RouterConfig = {
-        generatedPatterns: [],
+        generatedRules: [],
         ...(corpusCase.routerConfig as Partial<RouterConfig>),
     };
     const routing = route({files: corpusCase.changedFiles}, routerConfig);

--- a/workflows/review/eval/live-stage.ts
+++ b/workflows/review/eval/live-stage.ts
@@ -291,7 +291,7 @@ export const stageCase = (
 
     // Deterministic routing, exactly as the no-post runner computes it.
     const routerConfig: RouterConfig = {
-        generatedPatterns: [],
+        generatedRules: [],
         ...(corpusCase.routerConfig as Partial<RouterConfig>),
     };
     const routing = route({files: corpusCase.changedFiles}, routerConfig);

--- a/workflows/review/eval/runner.ts
+++ b/workflows/review/eval/runner.ts
@@ -350,7 +350,7 @@ export const runCase = (
 ): RunResult => {
     // 1. Deterministic routing over the changed files.
     const routerConfig: RouterConfig = {
-        generatedPatterns: [],
+        generatedRules: [],
         ...(corpusCase.routerConfig as Partial<RouterConfig>),
     };
     const routing = route({files: corpusCase.changedFiles}, routerConfig);

--- a/workflows/review/lib/check-consumer-config.ts
+++ b/workflows/review/lib/check-consumer-config.ts
@@ -585,12 +585,12 @@ export const checkConsumerConfig = (
 
     /* --- .gitattributes ---------------------------------------------------- */
 
-    const generatedPatterns = fs.existsSync(at(GITATTRIBUTES_PATH))
+    const generatedRules = fs.existsSync(at(GITATTRIBUTES_PATH))
         ? parseGitattributesGenerated(
               fs.readFileSync(at(GITATTRIBUTES_PATH), "utf8"),
           )
         : [];
-    if (!isGenerated(lockPath, generatedPatterns)) {
+    if (!isGenerated(lockPath, generatedRules)) {
         warn(
             "lock-not-marked-generated",
             `${lockPath} is not marked \`linguist-generated\` in ${GITATTRIBUTES_PATH}, so the reviewer line-reviews its own compiled output.`,
@@ -603,7 +603,7 @@ export const checkConsumerConfig = (
     // of compiler output line-reviewed. Installs predating gh-aw v0.83 lack the file.
     if (
         fs.existsSync(at(MAINTENANCE_WORKFLOW_PATH)) &&
-        !isGenerated(MAINTENANCE_WORKFLOW_PATH, generatedPatterns)
+        !isGenerated(MAINTENANCE_WORKFLOW_PATH, generatedRules)
     ) {
         warn(
             "maintenance-workflow-not-marked-generated",
@@ -637,7 +637,7 @@ export const checkConsumerConfig = (
     ];
     const selfRouting = route(
         {files: selfPaths.map((path) => ({path, status: "modified" as const}))},
-        {generatedPatterns, lensRules, riskRules},
+        {generatedRules, lensRules, riskRules},
     );
     const configFileTiers: Record<string, RiskTier> = {};
     for (const path of selfPaths) {
@@ -668,7 +668,7 @@ export const checkConsumerConfig = (
         }));
         const result: RoutingResult = route(
             {files},
-            {generatedPatterns, lensRules, riskRules},
+            {generatedRules, lensRules, riskRules},
         );
         const counts = emptyTierRecord(() => 0);
         const samples = emptyTierRecord<string[]>(() => []);
@@ -749,7 +749,7 @@ export const checkConsumerConfig = (
         const path = options.explainPath;
         const result = route(
             {files: [{path, status: "modified"}]},
-            {generatedPatterns, lensRules, riskRules},
+            {generatedRules, lensRules, riskRules},
         );
         const decision = result.perFile[0];
         explanation = {

--- a/workflows/review/lib/credit-cap.test.ts
+++ b/workflows/review/lib/credit-cap.test.ts
@@ -18,7 +18,7 @@ import {
  */
 
 /** The smallest router config the clamp path needs; the tier is explicit. */
-const minimalConfig: RouterConfig = {generatedPatterns: []};
+const minimalConfig: RouterConfig = {generatedRules: []};
 
 /** In-memory fs seam, mirroring router.test.ts's helper. */
 const fakeFs = (inputs: Record<string, string>) => {

--- a/workflows/review/lib/gitattributes.test.ts
+++ b/workflows/review/lib/gitattributes.test.ts
@@ -1,0 +1,70 @@
+import {describe, it, expect} from "vitest";
+
+import {isGenerated, parseGitattributesGenerated} from "./router.ts";
+
+/**
+ * `.gitattributes` generated-file classification, split from router.test.ts by
+ * concern and its max-lines budget (as credit-cap and lens-payloads are).
+ *
+ * What these pin is one semantic: git resolves an attribute per path by the LAST
+ * matching line, so `linguist-generated` is not a set of "generated globs" but an
+ * ordered list of verdicts. Reading it as any-match-wins silently skipped review
+ * of paths a repo had deliberately un-marked, which is why the ordering cases
+ * below are the point of the file rather than edge cases in it.
+ */
+
+describe("parseGitattributesGenerated", () => {
+    it("keeps every rule that mentions the attribute, in file order", () => {
+        const content = [
+            "# comment",
+            "",
+            "dist/** linguist-generated=true",
+            "vendor/** linguist-generated",
+            "generated/keep.ts -linguist-generated",
+            "src/*.ts text",
+            "other/*.js linguist-generated=false",
+        ].join("\n");
+        // Negations are retained rather than dropped: isGenerated resolves per
+        // path by last match, so a later `=false` has to be able to win. A line
+        // that never mentions the attribute (`src/*.ts text`) is not a rule.
+        expect(parseGitattributesGenerated(content)).toEqual([
+            {pattern: "dist/**", generated: true},
+            {pattern: "vendor/**", generated: true},
+            {pattern: "generated/keep.ts", generated: false},
+            {pattern: "other/*.js", generated: false},
+        ]);
+    });
+});
+
+describe("isGenerated", () => {
+    // Git resolves an attribute per path by LAST matching line. The reviewer read
+    // it as "any matching =true line wins", which silently skipped review of paths
+    // a repo had deliberately un-marked (observed in Khan/agent-settings, whose
+    // .gitattributes marks `.claude/**` generated and then un-marks
+    // `.claude/skills/**` so its skills stay visible and reviewable).
+    const rules = parseGitattributesGenerated(
+        [
+            ".claude/** linguist-generated=true",
+            ".claude/skills/** linguist-generated=false",
+        ].join("\n"),
+    );
+
+    it("lets a later negation un-mark an earlier broad glob", () => {
+        expect(isGenerated(".claude/hooks/git-filter.mjs", rules)).toBe(true);
+        expect(isGenerated(".claude/skills/foo/SKILL.md", rules)).toBe(false);
+    });
+
+    it("keeps ordering load-bearing: reversing the lines reverses the answer", () => {
+        const reversed = parseGitattributesGenerated(
+            [
+                ".claude/skills/** linguist-generated=false",
+                ".claude/** linguist-generated=true",
+            ].join("\n"),
+        );
+        expect(isGenerated(".claude/skills/foo/SKILL.md", reversed)).toBe(true);
+    });
+
+    it("treats a path no rule matches as source", () => {
+        expect(isGenerated("src/index.ts", rules)).toBe(false);
+    });
+});

--- a/workflows/review/lib/investigation-cap.test.ts
+++ b/workflows/review/lib/investigation-cap.test.ts
@@ -156,7 +156,7 @@ describe("DEFAULT_TOOL_CALL_CAPS", () => {
 
 describe("capsFromRunBudget", () => {
     // Build a real RunBudget via the production path rather than a hand literal.
-    const config: RouterConfig = {generatedPatterns: []};
+    const config: RouterConfig = {generatedRules: []};
 
     it("projects exactly the two cap fields out of a full RunBudget", () => {
         const budget = computeRunBudget("medium", false, config);
@@ -305,7 +305,7 @@ describe("InvestigationCap", () => {
     });
 
     it("builds a guard from a RunBudget whose caps match that budget", () => {
-        const budget = computeRunBudget("high", false, {generatedPatterns: []});
+        const budget = computeRunBudget("high", false, {generatedRules: []});
         const guard = InvestigationCap.fromRunBudget(budget);
         expect(guard.getCaps()).toEqual(capsFromRunBudget(budget));
     });

--- a/workflows/review/lib/router.test.ts
+++ b/workflows/review/lib/router.test.ts
@@ -50,7 +50,7 @@ const file = (
 // map lives in its own .github/aw/review/ROUTING file), so the tests supply
 // the rules they exercise, shaped like a typical consumer config.
 const baseConfig: RouterConfig = {
-    generatedPatterns: [],
+    generatedRules: [],
     lensRules: [
         {pattern: "**/*.sql", lenses: ["data-migrations"]},
         {pattern: "**/migrations/**", lenses: ["data-migrations"]},
@@ -117,24 +117,6 @@ describe("patternSpecificity", () => {
 /* Config parsers                                                             */
 /* -------------------------------------------------------------------------- */
 
-describe("parseGitattributesGenerated", () => {
-    it("collects linguist-generated patterns and honours negation", () => {
-        const content = [
-            "# comment",
-            "",
-            "dist/** linguist-generated=true",
-            "vendor/** linguist-generated",
-            "generated/keep.ts -linguist-generated",
-            "src/*.ts text",
-            "other/*.js linguist-generated=false",
-        ].join("\n");
-        expect(parseGitattributesGenerated(content)).toEqual([
-            "dist/**",
-            "vendor/**",
-        ]);
-    });
-});
-
 describe("teamSlug", () => {
     it("strips @, org prefix, trailing !, and lowercases", () => {
         expect(teamSlug("@Khan/Security!")).toBe("security");
@@ -165,14 +147,14 @@ describe("parseReviewers", () => {
 
 describe("route: classification", () => {
     it("marks linguist-generated files generated with no lenses/teams/tier", () => {
-        const generatedPatterns = parseGitattributesGenerated(
+        const generatedRules = parseGitattributesGenerated(
             "dist/** linguist-generated=true",
         );
-        expect(isGenerated("dist/bundle.js", generatedPatterns)).toBe(true);
+        expect(isGenerated("dist/bundle.js", generatedRules)).toBe(true);
 
         const result = route(
             {files: [file("dist/bundle.js")]},
-            {...baseConfig, generatedPatterns},
+            {...baseConfig, generatedRules},
         );
         expect(result.perFile[0]).toMatchObject({
             path: "dist/bundle.js",
@@ -543,7 +525,11 @@ describe("toRoutingJson", () => {
         const reviewerRules = parseReviewers("src/auth/ @Khan/Security");
         const result = route(
             {files: [file("src/auth/login.ts"), file("dist/bundle.js")]},
-            {...baseConfig, generatedPatterns: ["dist/**"], reviewerRules},
+            {
+                ...baseConfig,
+                generatedRules: [{pattern: "dist/**", generated: true}],
+                reviewerRules,
+            },
         );
         const json = toRoutingJson(result);
         // Every tier is emitted in the display casing review.md consumes.

--- a/workflows/review/lib/router.ts
+++ b/workflows/review/lib/router.ts
@@ -214,8 +214,12 @@ export type RunBudget = {
 };
 
 export type RouterConfig = {
-    /** linguist-generated globs (from `.gitattributes`). */
-    generatedPatterns: string[];
+    /**
+     * `linguist-generated` rules from `.gitattributes`, in file order. Order is
+     * load-bearing: {@link isGenerated} resolves per path by last match, so a
+     * later negation un-marks an earlier glob.
+     */
+    generatedRules: GeneratedRule[];
     /**
      * path->lens rules, from the consumer's `ROUTING` file
      * ({@link parseRoutingConfig}). No default: absent config means no
@@ -303,13 +307,28 @@ export type RouteInput = {
 /* -------------------------------------------------------------------------- */
 
 /**
- * Extract the linguist-generated globs from `.gitattributes` content. A line
- * assigns attributes to a pattern: `<pattern> attr1 attr2 ...`. We collect the
- * pattern when it sets `linguist-generated` truthy, and honour explicit
- * negation (`-linguist-generated` or `linguist-generated=false`).
+ * One `.gitattributes` line's verdict on `linguist-generated` for the paths its
+ * glob matches. Negations are kept rather than dropped, because git resolves the
+ * attribute per path by LAST matching line, so a later `=false` has to be able to
+ * override an earlier `=true` — see {@link isGenerated}.
  */
-export const parseGitattributesGenerated = (content: string): string[] => {
-    const patterns: string[] = [];
+export type GeneratedRule = {
+    pattern: string;
+    generated: boolean;
+};
+
+/**
+ * Extract the `linguist-generated` rules from `.gitattributes` content, in file
+ * order. A line assigns attributes to a pattern: `<pattern> attr1 attr2 ...`; a
+ * line that mentions the attribute either way becomes a rule, set by
+ * `linguist-generated` / `linguist-generated=true` and cleared by
+ * `-linguist-generated` / `linguist-generated=false`. Lines that never mention it
+ * are not rules at all and are skipped, so they cannot shadow a real one.
+ */
+export const parseGitattributesGenerated = (
+    content: string,
+): GeneratedRule[] => {
+    const rules: GeneratedRule[] = [];
     for (const rawLine of content.split(/\r?\n/)) {
         const line = rawLine.trim();
         if (line === "" || line.startsWith("#")) {
@@ -320,9 +339,8 @@ export const parseGitattributesGenerated = (content: string): string[] => {
         if (pattern === undefined) {
             continue;
         }
-        const attrs = tokens.slice(1);
-        let generated = false;
-        for (const attr of attrs) {
+        let generated: boolean | undefined;
+        for (const attr of tokens.slice(1)) {
             if (
                 attr === "linguist-generated" ||
                 attr === "linguist-generated=true"
@@ -335,11 +353,11 @@ export const parseGitattributesGenerated = (content: string): string[] => {
                 generated = false;
             }
         }
-        if (generated) {
-            patterns.push(pattern);
+        if (generated !== undefined) {
+            rules.push({pattern, generated});
         }
     }
-    return patterns;
+    return rules;
 };
 
 /**
@@ -392,11 +410,29 @@ export const parseReviewers = (content: string): ReviewerRule[] => {
 /* Per-file decisions                                                        */
 /* -------------------------------------------------------------------------- */
 
-/** Whether `path` matches any linguist-generated glob. */
+/**
+ * Whether `path` is linguist-generated, resolved the way git resolves an
+ * attribute: the LAST matching rule wins, so a `linguist-generated=false` line
+ * placed after a broad `=true` glob un-marks the paths it covers. A path no rule
+ * matches is source.
+ *
+ * Scanning in reverse rather than collecting only the `=true` patterns is the
+ * whole point: a repo that marks `.claude/**` generated and then un-marks
+ * `.claude/skills/**` means its skills to be reviewed, and the earlier
+ * any-match-wins reading silently skipped them.
+ */
 export const isGenerated = (
     path: string,
-    generatedPatterns: string[],
-): boolean => generatedPatterns.some((pattern) => matchesGlob(path, pattern));
+    generatedRules: readonly GeneratedRule[],
+): boolean => {
+    for (let i = generatedRules.length - 1; i >= 0; i--) {
+        const rule = generatedRules[i];
+        if (matchesGlob(path, rule.pattern)) {
+            return rule.generated;
+        }
+    }
+    return false;
+};
 
 /** Specialist lenses for one path (union of all matching rules, deduped). */
 const lensesForFile = (path: string, lensRules: LensRule[]): Lens[] => {
@@ -539,7 +575,7 @@ export const route = (
     let hasSource = false;
 
     for (const file of input.files) {
-        const generated = isGenerated(file.path, config.generatedPatterns);
+        const generated = isGenerated(file.path, config.generatedRules);
 
         if (generated) {
             // Generated files: contents are not analysed, so no lenses, no team
@@ -829,7 +865,7 @@ export const runCli = (
         };
     });
 
-    const generatedPatterns = fs.existsSync(repoPath(GITATTRIBUTES_PATH))
+    const generatedRules = fs.existsSync(repoPath(GITATTRIBUTES_PATH))
         ? parseGitattributesGenerated(readText(repoPath(GITATTRIBUTES_PATH)))
         : [];
     const reviewerRules = fs.existsSync(repoPath(REVIEWERS_PATH))
@@ -896,7 +932,7 @@ export const runCli = (
     }
 
     const result = route(input, {
-        generatedPatterns,
+        generatedRules,
         reviewerRules,
         lensRules: routingFileConfig.lensRules,
         riskRules: routingFileConfig.riskRules,


### PR DESCRIPTION
> **Stacked on #317** (base is `review-onboarding-skill-and-checker`). The rename touches `check-consumer-config.ts`, which only exists on that branch. Merge #317 first.

## The bug

The router read `.gitattributes` as a *set of generated globs* and asked whether a path matched **any** of them:

```ts
export const isGenerated = (path, generatedPatterns) =>
    generatedPatterns.some((pattern) => matchesGlob(path, pattern));
```

Git resolves an attribute per path by the **last** matching line. A negation placed after a broad glob is how a repo says "this subtree is generated, *except* this part". The parser computed each line's verdict correctly and then threw the negations away, keeping only the `=true` patterns — so an un-marked path still matched the earlier broad glob and came back generated.

Generated files are excluded from review entirely. So the reviewer was silently skipping exactly the files a repo had gone out of its way to keep visible.

## The fix

`parseGitattributesGenerated` returns ordered `GeneratedRule[]` (`{pattern, generated}`) instead of `string[]`, keeping negations. `isGenerated` scans in reverse and returns the first matching rule's verdict; a path no rule matches is source. A line that never mentions the attribute is not a rule at all, so it cannot shadow one. `RouterConfig.generatedPatterns` becomes `generatedRules` to match what it carries.

## How it was found, and what it was hiding

Onboarding `Khan/agent-settings` ([Khan/agent-settings#48](https://github.com/Khan/agent-settings/pull/48)). That repo installs its own generated agent config into itself, so its `.gitattributes` marks `.claude/**`, `.codex/**`, `.cursor/**` and `.pi/**` generated — then un-marks two paths, with a comment saying why:

```
# Hand-authored sources that live under the generated agent dirs — keep them
# visible in diffs and counted in language stats.
.claude/skills/** linguist-generated=false
.pi/git/** linguist-generated=false
```

`.claude/skills/new-repo-config/SKILL.md` is executable prose that steers every Claude session in that repo. Before:

```
Explanation: .claude/skills/new-repo-config/SKILL.md
  tier    trivial (generated)
```

After:

```
Explanation: .claude/skills/new-repo-config/SKILL.md
  tier    medium
  rules   (last one wins)
            **/*.md  tier=trivial
            .claude/skills/**  tier=medium
```

Its generated count drops from 36 to 34 over 253 tracked files.

## Blast radius

Narrow and one-directional — strictly **more** review, never less. Only a repo that actually writes a negation *after* a broader `=true` glob changes at all:

| Repo | Negations | Effect |
| --- | --- | --- |
| `Khan/actions` | none | none |
| `Khan/frontend` | none | none |
| `Khan/webapp` | one | **none** — see below |
| `Khan/agent-settings` | two | 2 files become reviewable, as intended |

webapp's single negation is `services/ai-guide/cmd/componentgen/main.go linguist-generated=false`, whose comment says "Prevent the componentgen command from being incorrectly detected as generated". That targets Linguist's *content* heuristic, not an earlier `.gitattributes` rule: no earlier rule in that file matches the path, so the router already classified it as source and still does. I checked each repo's `.gitattributes` rather than reasoning from the shape of the fix.

## Tests

The gitattributes tests move to `lib/gitattributes.test.ts`, following `credit-cap` and `lens-payloads`, because adding the ordering cases put `router.test.ts` over its 1000-line cap. Three new cases, and the middle one is the one that matters: it reverses the two lines and asserts the answer reverses, so the ordering is pinned as load-bearing rather than incidental.

911 tests pass across 38 files; eslint and prettier clean over `workflows/`, `utils/`, `actions/`, `config/`, `types/`.

## Note on what typechecking does not cover

The root `tsconfig.json` `include` lists `actions/**`, `utils/**`, `types/**`, `config/**` and `vitest.config.ts` — **not `workflows/**`**. So `pnpm typecheck` does not typecheck the reviewer lib at all, and the `generatedRules: ["dist/**"]` call site this rename invalidated produced no type error; only running the tests caught it. Worth fixing separately, since it means every type contract in `workflows/review/lib/` is currently enforced only by whatever the tests happen to exercise.