### PR TITLE
fix-workflows: stop reformatting generated workflows

### DIFF
--- a/.changeset/fix-workflows-skip-generated.md
+++ b/.changeset/fix-workflows-skip-generated.md
@@ -1,0 +1,27 @@
+---
+"fix-workflows": minor
+---
+
+fix-workflows: stop reformatting generated workflows
+
+The YAML fixer already skipped `*.lock.yml`, but the separate `oxfmt` step in
+`action.yml` (and its `cli.ts` equivalent) globbed `.github/workflows/**/*.yml`
+with no exclusions, so it reformatted the compiled agentic workflows the fixer had
+deliberately left alone. The "this file needs updating" annotation that follows
+then points a maintainer at compiler output, and applying it desyncs a committed
+lock from `gh aw compile`.
+
+Both invocations now exclude the generator-owned workflows via negated globs, and
+the fixer's own skip list is a named, tested predicate (`isGeneratedWorkflow`) so
+the three call sites cannot drift apart again. `agentics-maintenance.yml` joins
+`*.lock.yml` in that set: gh-aw regenerates it unconditionally and it is not named
+`*.lock.yml`, so nothing was skipping it — it took 6 checkout-followed-by-setup
+violations and 12 `runs-on` rewrites on a file no human can fix.
+
+Negated globs rather than `ignorePatterns` in `.oxfmtrc.json`, because that config
+lives in the action's own directory rather than the repo being formatted and its
+patterns do not resolve against the working directory (verified: the lock was still
+rewritten).
+
+Observed on Khan/agent-settings#48, which is the first repo to run this action over
+a directory containing compiled agentic workflows.

--- a/actions/fix-workflows/action.yml
+++ b/actions/fix-workflows/action.yml
@@ -36,12 +36,21 @@ runs:
                       core.setFailed(err.message)
                   }
 
+        # The negations must match `isGeneratedWorkflow` in index.ts. Without them
+        # this step reformats compiler output that the YAML fixer above correctly
+        # skips, which desyncs a committed lock from `gh aw compile` and makes the
+        # next step annotate a generated file with a fix nobody should apply.
+        # `ignorePatterns` in .oxfmtrc.json cannot do this: the config lives in the
+        # action's directory, not the repo being formatted, and its patterns do not
+        # resolve against the working directory.
         - name: Format YAML files with oxfmt
           shell: bash
           run: |
               npx --yes oxfmt@0.44.0 --write \
                 --config "${{ github.action_path }}/.oxfmtrc.json" \
-                ".github/workflows/**/*.yml"
+                ".github/workflows/**/*.yml" \
+                '!.github/workflows/*.lock.yml' \
+                '!.github/workflows/agentics-maintenance.yml'
 
         - name: Show fix instructions
           shell: bash

--- a/actions/fix-workflows/cli.ts
+++ b/actions/fix-workflows/cli.ts
@@ -44,13 +44,24 @@ const core = {
 
 fixWorkflows({core, fixRunsOn, setupAction})
     .then(() => {
-        // Format workflow files with oxfmt after fixing lint violations.
+        // Format workflow files with oxfmt after fixing lint violations, skipping
+        // the generator-owned ones for the same reason the fixer does (see
+        // isGeneratedWorkflow in index.ts, and keep these globs in step with it and
+        // with action.yml). Negated globs rather than .oxfmtrc.json ignorePatterns:
+        // the config lives beside this script, not in the repo being formatted, and
+        // its patterns do not resolve against the working directory.
         const configPath = path.join(__dirname, ".oxfmtrc.json");
+        const skip = [
+            "!.github/workflows/*.lock.yml",
+            "!.github/workflows/agentics-maintenance.yml",
+        ]
+            .map((glob) => JSON.stringify(glob))
+            .join(" ");
         console.log("Formatting workflow files with oxfmt..."); // eslint-disable-line no-console
         execSync(
             `npx --yes oxfmt@0.44.0 --write --config ${JSON.stringify(
                 configPath,
-            )} ".github/workflows/**/*.yml"`,
+            )} ".github/workflows/**/*.yml" ${skip}`,
             {stdio: "inherit"},
         );
     })

--- a/actions/fix-workflows/generated-workflows.test.ts
+++ b/actions/fix-workflows/generated-workflows.test.ts
@@ -1,0 +1,38 @@
+import {describe, expect, it} from "vitest";
+
+import {isGeneratedWorkflow} from "./index.ts";
+
+/**
+ * Which `.github/workflows` entries a generator owns, split from index.test.ts to
+ * keep that file inside its 1000-line cap.
+ *
+ * This predicate is the single source of truth for a set that is duplicated as
+ * negated globs in action.yml and cli.ts. It exists because those three places
+ * diverged once: the YAML fixer skipped `*.lock.yml` while the oxfmt step did not.
+ */
+
+describe("isGeneratedWorkflow", () => {
+    // These files are compiler output. Fixing them is worse than useless: the fix
+    // is overwritten on the next `gh aw compile`, and the "this file needs
+    // updating" annotation invites a maintainer to desync a committed lock from
+    // its compiler. The oxfmt globs in action.yml and cli.ts must exclude exactly
+    // this set -- they diverged once, and only the formatter step touched locks.
+    it("skips compiled agentic workflow locks", () => {
+        expect(isGeneratedWorkflow("review.lock.yml")).toBe(true);
+        expect(isGeneratedWorkflow("autofix.lock.yml")).toBe(true);
+    });
+
+    it("skips gh-aw's maintenance workflow, which is not named *.lock.yml", () => {
+        expect(isGeneratedWorkflow("agentics-maintenance.yml")).toBe(true);
+    });
+
+    it("still checks hand-written workflows, including lookalikes", () => {
+        expect(isGeneratedWorkflow("node-ci.yml")).toBe(false);
+        expect(isGeneratedWorkflow("validate-workflows.yml")).toBe(false);
+        // Not a lock: the suffix test is `.lock.yml`, not `lock` anywhere.
+        expect(isGeneratedWorkflow("lock-threads.yml")).toBe(false);
+        expect(isGeneratedWorkflow("agentics-maintenance-notes.yml")).toBe(
+            false,
+        );
+    });
+});

--- a/actions/fix-workflows/index.ts
+++ b/actions/fix-workflows/index.ts
@@ -178,6 +178,31 @@ export function stepIgnoresSetup(step: YAMLMap): boolean {
 // File discovery
 // ---------------------------------------------------------------------------
 
+/**
+ * Workflow files this action must not touch because a generator owns them: the
+ * fix would be overwritten on the next `gh aw compile`, and worse, a maintainer
+ * who follows our own "this file needs updating" hint desyncs the committed file
+ * from its compiler.
+ *
+ * `*.lock.yml` is the compiled agentic workflow; `agentics-maintenance.yml` is
+ * gh-aw's scheduled housekeeping workflow, which is regenerated unconditionally
+ * and (unhelpfully) is not named `*.lock.yml`.
+ *
+ * The general rule would be "skip anything `.gitattributes` marks
+ * `linguist-generated`", which would need no updating as generators change.
+ * That is a larger change than this list and is left for when a third generated
+ * workflow shows up.
+ */
+export const GENERATED_WORKFLOWS = {
+    suffixes: [".lock.yml"],
+    names: ["agentics-maintenance.yml"],
+};
+
+/** Whether a `.github/workflows` entry is generator-owned (see above). */
+export const isGeneratedWorkflow = (name: string): boolean =>
+    GENERATED_WORKFLOWS.suffixes.some((suffix) => name.endsWith(suffix)) ||
+    GENERATED_WORKFLOWS.names.includes(name);
+
 function getFilesToCheck(): string[] {
     const files: string[] = [];
 
@@ -186,7 +211,7 @@ function getFilesToCheck(): string[] {
         if (
             entry.isFile() &&
             (entry.name.endsWith(".yml") || entry.name.endsWith(".yaml")) &&
-            !entry.name.endsWith(".lock.yml")
+            !isGeneratedWorkflow(entry.name)
         ) {
             files.push(path.join(".github", "workflows", entry.name));
         }


### PR DESCRIPTION
## The bug

The YAML fixer already skips compiled workflows:

```ts
(entry.name.endsWith(".yml") || entry.name.endsWith(".yaml")) &&
!entry.name.endsWith(".lock.yml")
```

But the **separate `oxfmt` step** in `action.yml` globbed `.github/workflows/**/*.yml` with no exclusions, so it reformatted the very files the fixer deliberately left alone. `cli.ts` had the same glob.

The consequence isn't a failed run — it's worse than that. The `Show fix instructions` step then annotates the generated file with `::warning file=…::This file needs updating. Run: pnpm dlx github:Khan/actions#fix-workflows-v3`, and a maintainer who follows that hint commits a reformatted lock that no longer matches `gh aw compile`.

## Why nobody noticed

`Khan/actions` doesn't run this action on itself, and webapp and frontend don't carry compiled agentic workflows in a repo that does. [Khan/agent-settings#48](https://github.com/Khan/agent-settings/pull/48) is the first install where both are true, and it reproduced immediately — two advisory annotations on that PR, on `review.lock.yml` and `agentics-maintenance.yml`.

I confirmed the reformatting is real rather than theoretical by running the pinned `oxfmt@0.44.0` with this action's own `.oxfmtrc.json` over a copy of a 123KB `review.lock.yml`: the checksum changed.

## The fix

Both invocations exclude generator-owned workflows, and the fixer's skip list becomes a named, tested predicate (`isGeneratedWorkflow`) so the three call sites cannot drift apart again.

**`agentics-maintenance.yml` joins `*.lock.yml` in that set.** gh-aw regenerates it unconditionally (deleting it doesn't stick) and it is *not* named `*.lock.yml`, so nothing was skipping it at all — the fixer wanted 6 checkout-followed-by-setup changes and 12 `runs-on` rewrites in a file no human can fix.

I deliberately did **not** implement the general rule, which would be "skip anything `.gitattributes` marks `linguist-generated`". That needs no updating as generators change and is the better long-term answer, but it means teaching this action to parse `.gitattributes`. The comment on `GENERATED_WORKFLOWS` says to do it when a third generated workflow shows up.

## Why negated globs and not `ignorePatterns`

The obvious fix is `ignorePatterns` in `.oxfmtrc.json`. It does not work here, and I tested it rather than assuming: that config lives in the **action's** directory (`--config "${{ github.action_path }}/.oxfmtrc.json"`), not the repo being formatted, and its patterns don't resolve against the working directory — the lock was still rewritten. Negated positional globs do work (verified: oxfmt reported `on 1 files` instead of 2, and the lock's checksum was unchanged).

The globs are duplicated in `action.yml` and `cli.ts`, which is the part I like least. `isGeneratedWorkflow` and its test are the mitigation: the comment at each site points at the predicate, and the test explains why the set must match.

## Tests

Four new cases in `actions/fix-workflows/generated-workflows.test.ts`, including the lookalikes that must *not* be skipped (`lock-threads.yml`, `agentics-maintenance-notes.yml`) since the suffix test is `.lock.yml` rather than `lock` anywhere. Split into its own file because adding them put `index.test.ts` over the repo's 1000-line cap.

58 tests pass; eslint and prettier clean.