### PR TITLE
review: tier the 27 paths that were falling to the router's default

### DIFF
--- a/.github/aw/review/ROUTING
+++ b/.github/aw/review/ROUTING
@@ -29,8 +29,20 @@ actions/**                   tier=high
 # This repo's own CI, the publish pipeline, and the compiled agentic workflows.
 .github/workflows/**         tier=high
 utils/**                     tier=high
+# A workflow staged for a human `git mv` into .github/workflows/ is CI the moment
+# it moves, and it is reviewed here or nowhere.
+.github-staging/**           tier=high
 # The shared reviewer's deterministic enforcement layer.
 workflows/review/lib/**      tier=high
+# The autofix workflow's enforcement layer. It PUSHES COMMITS to PRs in consuming
+# repos, so it has at least the blast radius of the reviewer lib beside it; it was
+# falling to the default `low` purely because no rule named it.
+workflows/autofix/lib/**     tier=high
+# The dependency sets these shared workflows install INSIDE a consumer's CI run
+# (review.md's pre-agent step is `npm ci` against the released lockfile), so a
+# dependency added here executes in every consuming repo.
+workflows/*/package.json     tier=high
+workflows/*/package-lock.json tier=high
 
 # Dev-only surfaces.
 workflows/review/eval/**     tier=low
@@ -55,9 +67,44 @@ workflows/*/CHANGELOG.md     tier=trivial
 # shed review dimensions for it.)
 .claude/skills/**            tier=medium
 workflows/review/eval/**/*.md tier=low
+# Same reasoning one directory over: Cursor rules steer an agent working here.
+.cursor/rules/**             tier=medium
 
 # The reviewer's own consumer config: config.md carries the add-reviewer team
 # allowlist and bot token, ROUTING sets these tiers, and the prose imports steer
 # every sub-agent. A PR tampering with any of them must not run at the trivial
 # or default budget.
 .github/aw/review/**         tier=high
+
+# gh-aw's action SHA lockfile: it pins every third-party action the compiled
+# workflows in this repo run. A diff here changes which third-party code executes
+# in our CI. Deliberately not classified generated even though `gh aw compile`
+# maintains it -- a SHA change is exactly what should be reviewed, not skipped.
+.github/aw/*.json            tier=high
+
+# Config that shapes releases, review routing, or what the reviewer itself can see,
+# without being executable: worth real review, short of the supply-chain tier.
+# `.changeset/config.json` shapes what gets versioned and tagged (the publish code
+# in utils/ and its version-sync test are the actual gate, hence medium not high);
+# `.github/REVIEWERS` is the ONLY source of the router's team ownership, so a wrong
+# line silently routes reviews to the wrong team or to nobody; `.gitattributes`
+# decides which files the reviewer treats as generated and therefore skips;
+# `tsconfig.json` decides what `pnpm typecheck` covers (today it excludes
+# `workflows/**` entirely, so nothing typechecks the reviewer lib).
+.changeset/config.json       tier=medium
+.github/REVIEWERS            tier=medium
+/.gitattributes              tier=medium
+/package.json                tier=medium
+/tsconfig.json               tier=medium
+
+# Repo-local dev surfaces: lint/format/test wiring, type shims, and eval output.
+# None of it ships, and none of it runs in another repo.
+/.eslintrc.js                tier=low
+/.prettierrc.js              tier=low
+/.gitignore                  tier=low
+/pnpm-workspace.yaml         tier=low
+/vitest.config.ts            tier=low
+config/**                    tier=low
+types/**                     tier=low
+.github/NOTIFIED             tier=low
+.github/review-eval/**       tier=low


### PR DESCRIPTION
The consumer-config checker from #317 reported that **27 of this repo's 430 tracked files matched no `tier=` rule** and silently took the router's default `low`. Most were harmless. One group was not.

## The one that matters

**`workflows/autofix/lib/*.ts` was `low`.** That code decides what the autofix workflow does, and autofix *pushes commits to PRs*. `workflows/review/lib/**` sits right next to it at `high`. There is no reading on which the autofix enforcement layer is lower-risk than the reviewer's; it was `low` purely because no rule named it.

## Also raised to `high`

| Path | Why |
| --- | --- |
| `.github/aw/actions-lock.json` | SHA pins for every third-party action our compiled workflows run; a diff changes which third-party code executes in our CI. |
| `.github-staging/**` | A workflow staged for a human `git mv` into `.github/workflows/` is CI the moment it moves. It is reviewed here or nowhere. |
| `workflows/*/package.json`, `workflows/*/package-lock.json` | `review.md`'s pre-agent step runs `npm ci` against the released lockfile **inside a consumer's CI**, so a dependency added here executes in every consuming repo. |

## Medium

Config that shapes releases, review routing, or what the reviewer itself can see, without being executable:

- `.changeset/config.json` — shapes what gets versioned and tagged. Medium rather than high because the publish code in `utils/` and its version-sync test are the actual gate.
- `.github/REVIEWERS` — the router's **only** source of team ownership, so a wrong line silently routes reviews to the wrong team, or to nobody.
- `.gitattributes` — decides which files the reviewer treats as generated and therefore skips entirely.
- `package.json`, `tsconfig.json`.

## Low, explicitly

Lint/format/test wiring, type shims, `.github/NOTIFIED`, and eval output. These were already effectively `low`; naming them means the next unrated file is a signal rather than noise.

## Verification

`check-consumer-config.ts --files-from` now reports **0 errors, 0 warnings** over all 430 files (was 1 warning naming the 27). `high` goes 100 → 109.

Each new tier is checked with `--explain` rather than inferred, including the ordering case that matters — autofix's own tests must still land at `low`:

```
Explanation: workflows/autofix/lib/scope.ts
  tier    high
  rules   (last one wins)
            workflows/autofix/lib/**  tier=high

Explanation: workflows/autofix/lib/scope.test.ts
  tier    low
  rules   (last one wins)
            workflows/autofix/lib/**  tier=high
            **/*.test.ts  tier=low
```

No recompile: `ROUTING` is read at run time by the router, not embedded at compile time. No changeset: `.github/` is excluded from `check-for-changeset`.

## Two things worth arguing with

- **`workflows/*/package-lock.json` at `high`** puts a lockfile in the highest tier. Tier drives review depth and budget rather than whether the file is read line-by-line, and a dependency addition that lands in every consumer's CI seems worth the depth — but if you'd rather it were `medium`, that's a defensible read.
- **`tsconfig.json` at `medium`** is partly a nudge: its `include` lists `actions/**`, `utils/**`, `types/**`, `config/**` and `vitest.config.ts`, so `pnpm typecheck` **does not cover `workflows/**` at all**. Nothing typechecks the reviewer lib today. I hit that in #320, where a rename invalidated a call site and only the tests caught it. Worth fixing separately.